### PR TITLE
fix: browser opening on macOS

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 
 	"github.com/fatih/color"
 	"github.com/tuist/guck/internal/config"


### PR DESCRIPTION
## Problem

The browser opening functionality was broken on macOS. When running `guck`, it would fail with:
```
Error: exec: "cmd": executable file not found in $PATH
```

## Root Cause

The previous implementation used version checks (`--version`) to detect which browser command to use:
- `xdg-open --version` (Linux)
- `open --version` (macOS)

However, macOS's `open` command doesn't support the `--version` flag, causing the check to fail and fall through to the Windows `cmd` command.

## Solution

Replace the version-based detection with `runtime.GOOS` platform detection:
- `darwin` → `open`
- `windows` → `cmd /C start`
- `default` (Linux, FreeBSD, etc.) → `xdg-open`

This is more reliable and matches the cross-platform build targets.

## Testing

- ✓ Code compiles
- ✓ Tests pass
- Manual testing needed on macOS to verify browser opens correctly