### PR TITLE
fix: link Guck title to GitHub repository

### DIFF
--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -649,30 +649,14 @@
                                     className="Subhead-heading d-flex flex-items-center"
                                     style={{ fontSize: "28px", gap: "12px" }}
                                 >
-                                    <span className="text-bold">Guck</span>
-                                    {diff?.repo_path && (
-                                        <a
-                                            href={`file://${diff.repo_path}`}
-                                            className="Link--muted"
-                                            style={{ fontSize: "14px" }}
-                                            title={diff.repo_path}
-                                        >
-                                            <svg
-                                                className="octicon"
-                                                width="16"
-                                                height="16"
-                                                viewBox="0 0 16 16"
-                                                fill="currentColor"
-                                            >
-                                                <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path>
-                                            </svg>
-                                            <span className="ml-1">
-                                                {diff.repo_path
-                                                    .split("/")
-                                                    .pop()}
-                                            </span>
-                                        </a>
-                                    )}
+                                    <a
+                                        href="https://github.com/tuist/guck"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="Link--primary text-bold"
+                                    >
+                                        Guck
+                                    </a>
                                 </div>
                                 <div className="Subhead-description mt-1">
                                     <span className="Label Label--secondary mr-2">


### PR DESCRIPTION
## Problem

The Guck title in the header linked to the local repository path using `file://` protocol, which doesn't work in browsers and shows a confusing tooltip with the local file path.

## Solution

Changed the Guck title to be a link to the GitHub repository (https://github.com/tuist/guck) that opens in a new tab.

## Changes

- Removed the local repository path link
- Made "Guck" title a direct link to the GitHub repository
- Added `target="_blank"` and `rel="noopener noreferrer"` for security
- Simplified the header by removing the repository path icon

## Testing

- ✓ Code compiles
- ✓ Link opens GitHub repository in new tab