### PR TITLE
chore: update mise install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Git diff review tool with a web interface, inspired by GitHub's pull request U
 
 ```bash
 # Using mise (recommended)
-mise use -g guck@latest
+mise use -g github:tuist/guck@latest
 
 # Or download from releases
 # https://github.com/tuist/guck/releases


### PR DESCRIPTION
Using `mise use -g guck@latest` will give:

```shell
mise ERROR guck not found in mise tool registry
mise ERROR Run with --verbose or MISE_VERBOSE=1 for more information
```

Addresses #3 