### PR TITLE
feat: display repository name in page title from remote origin

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -68,6 +68,21 @@ func (r *Repo) RepoPath() (string, error) {
 	return absPath, nil
 }
 
+// GetRemoteURL returns the URL of the origin remote, or empty string if not found
+func (r *Repo) GetRemoteURL() (string, error) {
+	remote, err := r.repo.Remote("origin")
+	if err != nil {
+		// No origin remote, return empty string
+		return "", nil
+	}
+
+	if len(remote.Config().URLs) == 0 {
+		return "", nil
+	}
+
+	return remote.Config().URLs[0], nil
+}
+
 func (r *Repo) GetDiffFiles(baseBranch string) ([]FileInfo, error) {
 	// Get the base branch reference
 	baseBranchRef, err := r.repo.Reference(plumbing.NewBranchReferenceName(baseBranch), true)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,10 +23,11 @@ type AppState struct {
 }
 
 type DiffResponse struct {
-	Files    []FileDiff `json:"files"`
-	Branch   string     `json:"branch"`
-	Commit   string     `json:"commit"`
-	RepoPath string     `json:"repo_path"`
+	Files     []FileDiff `json:"files"`
+	Branch    string     `json:"branch"`
+	Commit    string     `json:"commit"`
+	RepoPath  string     `json:"repo_path"`
+	RemoteURL string     `json:"remote_url,omitempty"`
 }
 
 type FileDiff struct {
@@ -128,6 +129,8 @@ func (s *AppState) diffHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	remoteURL, _ := gitRepo.GetRemoteURL() // Ignore error, remote is optional
+
 	files, err := gitRepo.GetDiffFiles(s.BaseBranch)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -149,10 +152,11 @@ func (s *AppState) diffHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := DiffResponse{
-		Files:    fileDiffs,
-		Branch:   currentBranch,
-		Commit:   currentCommit,
-		RepoPath: s.RepoPath,
+		Files:     fileDiffs,
+		Branch:    currentBranch,
+		Commit:    currentCommit,
+		RepoPath:  s.RepoPath,
+		RemoteURL: remoteURL,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -274,6 +274,32 @@
                     loadData();
                 }, []);
 
+                function updateDocumentTitle(repoPath, remoteURL) {
+                    let title = "Guck";
+
+                    if (remoteURL) {
+                        // Try to extract account/repo from remote URL
+                        // Supports formats like:
+                        // - https://github.com/account/repo.git
+                        // - git@github.com:account/repo.git
+                        // - https://github.com/account/repo
+                        const match = remoteURL.match(
+                            /[:/]([^/]+\/[^/]+?)(\.git)?$/,
+                        );
+                        if (match) {
+                            title = match[1];
+                        } else {
+                            // Fallback to local repo name
+                            title = repoPath.split("/").pop();
+                        }
+                    } else {
+                        // No remote URL, use local repository name
+                        title = repoPath.split("/").pop();
+                    }
+
+                    document.title = title;
+                }
+
                 async function loadData() {
                     try {
                         setLoading(true);
@@ -294,6 +320,12 @@
 
                         setStatus(statusData);
                         setDiff(diffData);
+
+                        // Update document title with repository name
+                        updateDocumentTitle(
+                            diffData.repo_path,
+                            diffData.remote_url,
+                        );
 
                         // Group comments by file_path
                         const commentsByFile = {};


### PR DESCRIPTION
## Overview

This PR enhances the browser page title to dynamically display the repository name extracted from the remote origin URL, providing better context when working with multiple repositories.

## Changes

### Backend
- **Added  method** to  - retrieves the origin remote URL
- **Updated  struct** in  - includes  field
- **Modified ** - fetches and includes remote URL in API response

### Frontend
- **Enhanced  function** in :
  - Extracts account/repo format from remote URL (e.g., `tuist/guck`)
  - Supports multiple URL formats:
    - HTTPS: `https://github.com/account/repo.git`
    - SSH: `git@github.com:account/repo.git`
    - No .git suffix: `https://github.com/account/repo`
  - Falls back to local repository name if no remote exists

## Benefits

- **Better tab identification** - Easy to distinguish between multiple repository reviews
- **Cleaner display** - Shows `tuist/guck` instead of `Guck - Git Diff Reviewer`
- **Graceful fallback** - Uses local repo name when no remote is configured
- **Platform agnostic** - Works with any Git hosting platform (GitHub, GitLab, etc.)

## Example

**Before:** All tabs show "Guck - Git Diff Reviewer"

**After:** 
- Tab shows `tuist/guck` (if remote exists)
- Tab shows `my-local-repo` (if no remote)

## Testing

Tested with:
- Repository with GitHub remote (HTTPS)
- Repository with GitHub remote (SSH)
- Repository without remote origin