### PR TITLE
feat: preserve diff prefixes (+/-) in syntax-highlighted code

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -70,6 +70,12 @@
                 overflow-x: auto;
             }
 
+            .diff-prefix {
+                display: inline-block;
+                width: 1ch;
+                user-select: none;
+            }
+
             .diff-line.addition {
                 background-color: rgba(46, 160, 67, 0.15);
             }
@@ -436,6 +442,13 @@
                         highlightedContent = content;
                     }
 
+                    // Add the prefix back to the highlighted content
+                    const prefixSpan =
+                        prefix !== " "
+                            ? `<span class="diff-prefix">${prefix}</span>`
+                            : '<span class="diff-prefix"> </span>';
+                    const fullContent = prefixSpan + highlightedContent;
+
                     return (
                         <React.Fragment key={index}>
                             <div className="diff-line-wrapper">
@@ -457,7 +470,7 @@
                                     <span
                                         className="diff-line-content"
                                         dangerouslySetInnerHTML={{
-                                            __html: highlightedContent,
+                                            __html: fullContent,
                                         }}
                                     />
                                 </div>


### PR DESCRIPTION
## Changes

This PR enhances the diff viewer to preserve and display the diff prefixes (+/-) in syntax-highlighted code lines.

### What was changed:
- Modified the `renderDiffLine` function in `static/index.html` to include the diff prefix (+, -, or space) when rendering syntax-highlighted content
- Added CSS styling for the `.diff-prefix` class to ensure proper display and alignment
- The prefix character is now non-selectable (user-select: none) to prevent it from being copied accidentally

### Why this is useful:
Previously, the diff prefixes were removed before syntax highlighting, making it harder to visually distinguish between added and removed lines when looking at the code itself (vs. relying only on background colors). Now users can see both:
1. The background color indicating the line type (green for additions, red for deletions)
2. The actual +/- prefix character in the code, just like in traditional diff views

This provides a more familiar and accessible diff viewing experience, especially for users who rely on the prefix characters for quick scanning.

### Testing:
- Tested locally by running the guck server and viewing diffs with various file types
- Verified that syntax highlighting still works correctly
- Confirmed that the prefix characters display properly for additions, deletions, and context lines