### PR TITLE
feat: make repo_path required in MCP tools and simplify MCP command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add to your Claude Desktop configuration:
   "mcpServers": {
     "guck": {
       "command": "/path/to/guck",
-      "args": ["mcp", "stdio"]
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,7 +139,7 @@ If you have [mise](https://mise.jdx.dev/) installed:
   "mcpServers": {
     "guck": {
       "command": "mise",
-      "args": ["x", "ubi:tuist/guck@latest", "--", "guck", "mcp", "stdio"]
+      "args": ["x", "ubi:tuist/guck@latest", "--", "guck", "mcp"]
     }
   }
 }
@@ -154,7 +154,7 @@ This ensures you always use the latest version of Guck without needing to specif
   "mcpServers": {
     "guck": {
       "command": "/path/to/guck",
-      "args": ["mcp", "stdio"]
+      "args": ["mcp"]
     }
   }
 }
@@ -173,7 +173,7 @@ After adding this configuration, restart Claude Code/Desktop. Guck will be avail
 Lists code review comments with optional filtering.
 
 **Parameters:**
-- `repo_path` (optional): Path to the repository (defaults to current working directory)
+- `repo_path` (required): Absolute path to the git repository
 - `branch` (optional): Filter by branch name
 - `commit` (optional): Filter by commit hash
 - `file_path` (optional): Filter by file path
@@ -184,6 +184,7 @@ Lists code review comments with optional filtering.
 {
   "name": "list_comments",
   "arguments": {
+    "repo_path": "/Users/username/projects/my-repo",
     "file_path": "main.go",
     "resolved": false
   }
@@ -215,15 +216,16 @@ Lists code review comments with optional filtering.
 Marks a comment as resolved and tracks who resolved it.
 
 **Parameters:**
+- `repo_path` (required): Absolute path to the git repository
 - `comment_id` (required): The ID of the comment to resolve
 - `resolved_by` (required): Identifier of who/what is resolving the comment (e.g., "claude", "copilot", "user-name")
-- `repo_path` (optional): Path to the repository (defaults to current working directory)
 
 **Example Request:**
 ```json
 {
   "name": "resolve_comment",
   "arguments": {
+    "repo_path": "/Users/username/projects/my-repo",
     "comment_id": "1234567890-0",
     "resolved_by": "claude"
   }
@@ -251,26 +253,7 @@ Once configured, you can ask Claude to interact with your code reviews:
 - "Resolve the comment with ID 1234567890-0"
 - "What comments were added on the feature/auth branch?"
 
-#### Legacy Command-line Usage
 
-For testing or scripting, you can also use the legacy command-line interface:
-
-```bash
-# List available tools
-guck mcp list-tools
-
-# List all comments (JSON via stdin)
-echo '{}' | guck mcp call-tool list_comments
-
-# Filter by file
-echo '{"file_path": "main.go"}' | guck mcp call-tool list_comments
-
-# Filter unresolved comments
-echo '{"resolved": false}' | guck mcp call-tool list_comments
-
-# Resolve a comment
-echo '{"comment_id": "1234567890-0", "resolved_by": "me"}' | guck mcp call-tool resolve_comment
-```
 
 ## Development
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -42,7 +42,10 @@ type ServerInfo struct {
 }
 
 type Capabilities struct {
-	Tools map[string]interface{} `json:"tools"`
+	Tools *ToolsCapability `json:"tools,omitempty"`
+}
+
+type ToolsCapability struct {
 }
 
 type ListToolsResult struct {
@@ -66,7 +69,7 @@ type ToolContent struct {
 }
 
 // StartStdioServer starts the MCP server using stdio transport
-func StartStdioServer(workingDir string) error {
+func StartStdioServer() error {
 	// Configure logging to stderr (stdout is reserved for JSON-RPC)
 	log.SetOutput(os.Stderr)
 	log.SetPrefix("[guck-mcp] ")
@@ -103,7 +106,7 @@ func StartStdioServer(workingDir string) error {
 			response = handleToolsList(request)
 
 		case "tools/call":
-			response = handleToolsCall(request, workingDir)
+			response = handleToolsCall(request)
 
 		default:
 			response = &JSONRPCResponse{
@@ -132,10 +135,10 @@ func handleInitialize(request JSONRPCRequest) *JSONRPCResponse {
 			ProtocolVersion: "2024-11-05",
 			ServerInfo: ServerInfo{
 				Name:    "guck",
-				Version: "0.1.0",
+				Version: "0.5.0",
 			},
 			Capabilities: Capabilities{
-				Tools: map[string]interface{}{},
+				Tools: &ToolsCapability{},
 			},
 		},
 	}
@@ -205,7 +208,7 @@ func handleToolsList(request JSONRPCRequest) *JSONRPCResponse {
 	}
 }
 
-func handleToolsCall(request JSONRPCRequest, workingDir string) *JSONRPCResponse {
+func handleToolsCall(request JSONRPCRequest) *JSONRPCResponse {
 	params, ok := request.Params.(map[string]interface{})
 	if !ok {
 		return &JSONRPCResponse{
@@ -253,10 +256,10 @@ func handleToolsCall(request JSONRPCRequest, workingDir string) *JSONRPCResponse
 
 	switch toolName {
 	case "list_comments":
-		result, toolErr = ListComments(json.RawMessage(argsJSON), workingDir)
+		result, toolErr = ListComments(json.RawMessage(argsJSON))
 
 	case "resolve_comment":
-		result, toolErr = ResolveComment(json.RawMessage(argsJSON), workingDir)
+		result, toolErr = ResolveComment(json.RawMessage(argsJSON))
 
 	default:
 		return &JSONRPCResponse{

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -113,26 +112,9 @@ func main() {
 				},
 			},
 			{
-				Name:  "mcp",
-				Usage: "MCP (Model Context Protocol) server for LLM integrations",
-				Subcommands: []*cli.Command{
-					{
-						Name:   "stdio",
-						Usage:  "Start MCP server with stdio transport (for integration with Claude Code, etc.)",
-						Action: mcpStdio,
-					},
-					{
-						Name:   "list-tools",
-						Usage:  "List available MCP tools (legacy)",
-						Action: mcpListTools,
-					},
-					{
-						Name:      "call-tool",
-						Usage:     "Call an MCP tool (legacy)",
-						ArgsUsage: "<tool-name>",
-						Action:    mcpCallTool,
-					},
-				},
+				Name:   "mcp",
+				Usage:  "Start MCP (Model Context Protocol) server for LLM integrations",
+				Action: mcpStdio,
 			},
 		},
 		Action: openBrowser,
@@ -552,72 +534,6 @@ func showConfig(c *cli.Context) error {
 }
 
 func mcpStdio(c *cli.Context) error {
-	// Get current working directory
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get working directory: %w", err)
-	}
-
 	// Start MCP server with stdio transport
-	return mcp.StartStdioServer(workingDir)
-}
-
-func mcpListTools(c *cli.Context) error {
-	tools := mcp.ListTools()
-	data, err := json.MarshalIndent(tools, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to encode tools: %w", err)
-	}
-	fmt.Println(string(data))
-	return nil
-}
-
-func mcpCallTool(c *cli.Context) error {
-	if c.NArg() < 1 {
-		return fmt.Errorf("tool name required")
-	}
-
-	toolName := c.Args().Get(0)
-
-	// Get current working directory
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get working directory: %w", err)
-	}
-
-	// Read params from stdin
-	var params json.RawMessage
-	if err := json.NewDecoder(os.Stdin).Decode(&params); err != nil {
-		return fmt.Errorf("failed to parse params: %w", err)
-	}
-
-	var result interface{}
-	var toolErr error
-
-	switch toolName {
-	case "list_comments":
-		result, toolErr = mcp.ListComments(params, workingDir)
-	case "resolve_comment":
-		result, toolErr = mcp.ResolveComment(params, workingDir)
-	default:
-		return fmt.Errorf("unknown tool: %s", toolName)
-	}
-
-	response := map[string]interface{}{}
-	if toolErr != nil {
-		response["error"] = map[string]interface{}{
-			"code":    500,
-			"message": toolErr.Error(),
-		}
-	} else {
-		response["result"] = result
-	}
-
-	data, err := json.MarshalIndent(response, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to encode response: %w", err)
-	}
-
-	fmt.Println(string(data))
-	return nil
+	return mcp.StartStdioServer()
 }


### PR DESCRIPTION
## Summary

This PR makes `repo_path` a required parameter for MCP tools and simplifies the MCP command interface.

## Problem

The current implementation had two issues:

1. **Incorrect working directory assumption**: The MCP server was using the working directory from where it was started, which is determined by the MCP client configuration (e.g., Claude Desktop), not the user's intended repository.

2. **Confusing command structure**: The `guck mcp stdio` command with legacy `list-tools` and `call-tool` subcommands was unnecessarily complex.

## Changes

### Breaking Changes
- **`repo_path` is now required**: MCP tools (`list_comments`, `resolve_comment`) now require the `repo_path` parameter to be explicitly specified instead of defaulting to the working directory.

### API Changes
- Removed `workingDir` parameter from MCP server initialization
- Updated tool schemas to mark `repo_path` as required
- Added validation to return clear error messages when `repo_path` is missing

### Command Simplification
- **Before**: `guck mcp stdio` (plus legacy `list-tools` and `call-tool`)
- **After**: `guck mcp` (single command to start MCP server)
- Removed legacy command-line interface for MCP tools
- Fixed MCP server capabilities structure for proper client connection

### Documentation
- Updated README and docs with new command syntax
- Updated all examples to include required `repo_path` parameter
- Removed references to legacy commands

### Tests
- Updated all tests to pass `repo_path` explicitly
- Added test to verify error when `repo_path` is missing
- All tests passing ✅

## Migration Guide

If you're using the MCP integration with Claude Code/Desktop:

**Old configuration:**
```json
{
  "mcpServers": {
    "guck": {
      "command": "/path/to/guck",
      "args": ["mcp", "stdio"]
    }
  }
}
```

**New configuration:**
```json
{
  "mcpServers": {
    "guck": {
      "command": "/path/to/guck",
      "args": ["mcp"]
    }
  }
}
```

When using the tools, you must now specify the repository path:
```json
{
  "name": "list_comments",
  "arguments": {
    "repo_path": "/Users/username/projects/my-repo",
    "resolved": false
  }
}
```