### PR TITLE
fix: Line number counting in diff view to exclude deleted lines

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -408,7 +408,13 @@
                     return langMap[ext] || "javascript";
                 }
 
-                function renderDiffLine(line, index, filePath, fileComments) {
+                function renderDiffLine(
+                    line,
+                    lineNumber,
+                    filePath,
+                    fileComments,
+                    key,
+                ) {
                     const prefix = line[0];
                     const content = line.slice(1);
                     let lineClass = "context";
@@ -418,8 +424,6 @@
                     } else if (prefix === "-") {
                         lineClass = "deletion";
                     }
-
-                    const lineNumber = index + 1;
                     const lineComments = (fileComments || []).filter(
                         (c) => c.line_number === lineNumber,
                     );
@@ -450,7 +454,7 @@
                     const fullContent = prefixSpan + highlightedContent;
 
                     return (
-                        <React.Fragment key={index}>
+                        <React.Fragment key={key}>
                             <div className="diff-line-wrapper">
                                 <button
                                     className="add-comment-btn"
@@ -724,23 +728,41 @@
                                                     <>
                                                         <div className="Box-body p-0">
                                                             <div className="file-diff-content">
-                                                                {file.patch
-                                                                    .split("\n")
-                                                                    .map(
+                                                                {(() => {
+                                                                    const lines =
+                                                                        file.patch.split(
+                                                                            "\n",
+                                                                        );
+                                                                    let currentLineNumber = 0;
+                                                                    return lines.map(
                                                                         (
                                                                             line,
                                                                             index,
-                                                                        ) =>
-                                                                            renderDiffLine(
+                                                                        ) => {
+                                                                            const prefix =
+                                                                                line[0];
+                                                                            // Only increment line number for additions and context lines (not deletions)
+                                                                            if (
+                                                                                prefix ===
+                                                                                    "+" ||
+                                                                                prefix ===
+                                                                                    " "
+                                                                            ) {
+                                                                                currentLineNumber++;
+                                                                            }
+                                                                            return renderDiffLine(
                                                                                 line,
-                                                                                index,
+                                                                                currentLineNumber,
                                                                                 file.path,
                                                                                 comments[
                                                                                     file
                                                                                         .path
                                                                                 ],
-                                                                            ),
-                                                                    )}
+                                                                                index,
+                                                                            );
+                                                                        },
+                                                                    );
+                                                                })()}
                                                             </div>
                                                         </div>
                                                     </>


### PR DESCRIPTION
## Problem

The line numbers displayed in the diff view were incorrectly counting deleted lines (shown with red/pink background). This caused the line numbers on the left side to not accurately reflect the actual line numbers in the new version of the file.

## Solution

Modified the line number calculation logic to only increment the line counter for:
- Addition lines (prefix `+`)
- Context lines (prefix ` `)

Deleted lines (prefix `-`) are now excluded from the count.

## Changes

- Updated `renderDiffLine` function to accept line number as a parameter instead of calculating it from the index
- Modified the line rendering logic to track line numbers separately, incrementing only for non-deletion lines
- Used the array index as the React key to maintain proper component identity

## Testing

- Built the application successfully
- Verified the diff shows correct syntax

Fixes the issue shown in the screenshot where deleted lines were being counted in the left-side line numbers.