### PR TITLE
fix: resolve syntax highlighting theme conflict causing dark comments

### DIFF
--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -41,16 +41,16 @@
             /* Hide/show highlight.js themes based on color mode */
             /* Default to light theme, hide dark */
             #hljs-dark {
-                display: none !important;
+                display: none;
             }
 
             /* When in dark mode, show dark and hide light */
             [data-color-mode="dark"] #hljs-light {
-                display: none !important;
+                display: none;
             }
 
             [data-color-mode="dark"] #hljs-dark {
-                display: block !important;
+                display: block;
             }
 
             .file-diff-content {
@@ -395,19 +395,6 @@
                     const html = document.documentElement;
                     html.setAttribute("data-color-mode", theme);
                     localStorage.setItem("guck-theme", theme);
-
-                    // Update highlight.js theme
-                    const lightTheme = document.getElementById("hljs-light");
-                    const darkTheme = document.getElementById("hljs-dark");
-                    if (lightTheme && darkTheme) {
-                        if (theme === "dark") {
-                            lightTheme.disabled = true;
-                            darkTheme.disabled = false;
-                        } else {
-                            lightTheme.disabled = false;
-                            darkTheme.disabled = true;
-                        }
-                    }
                 }, [theme]);
 
                 const toggleTheme = () => {


### PR DESCRIPTION
## Problem

Code comments in the diff view were appearing dark/unreadable due to conflicting theme switching mechanisms.

## Solution

This PR fixes the issue by:

1. **Removing `!important` flags from CSS theme toggle rules** - These were causing conflicts with the theme switching mechanism
2. **Simplifying theme switching logic** - Removed redundant JavaScript code that was manipulating the `disabled` property on stylesheets
3. **Relying solely on CSS `data-color-mode` attribute** - More reliable and maintainable approach

## Changes

- Simplified CSS rules for toggling between highlight.js light/dark themes
- Removed JavaScript code that was competing with CSS for theme control
- Theme switching now works properly through the `data-color-mode` attribute

## Testing

- Verify that code comments display with appropriate colors in both light and dark modes
- Confirm theme switching works correctly
- Check that syntax highlighting for all supported languages works as expected

Fixes the issue where comments appeared with dark colors on light backgrounds (or vice versa).