### PR TITLE
feat: apply syntax highlighting to added and deleted lines

### DIFF
--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -709,9 +709,9 @@
                     const commentKey = `${filePath}:${lineNumber}`;
                     const isCommentActive = activeCommentLine === commentKey;
 
-                    // Only apply syntax highlighting to context lines (not additions/deletions)
+                    // Apply syntax highlighting to all lines (context, additions, and deletions)
                     let displayContent = content;
-                    if (lineClass === "context" && window.hljs) {
+                    if (window.hljs) {
                         const language = getLanguageFromPath(filePath);
                         try {
                             const result = hljs.highlight(content, {
@@ -743,18 +743,12 @@
                                     <span className="diff-line-number">
                                         {lineNumber}
                                     </span>
-                                    {lineClass === "context" ? (
-                                        <span
-                                            className="diff-line-content"
-                                            dangerouslySetInnerHTML={{
-                                                __html: displayContent,
-                                            }}
-                                        />
-                                    ) : (
-                                        <span className="diff-line-content">
-                                            {content}
-                                        </span>
-                                    )}
+                                    <span
+                                        className="diff-line-content"
+                                        dangerouslySetInnerHTML={{
+                                            __html: displayContent,
+                                        }}
+                                    />
                                 </div>
                             </div>
                             {lineNotes.map((note) => (


### PR DESCRIPTION
## Description

This PR extends syntax highlighting to apply to added (+) and deleted (-) lines in the diff view, in addition to context lines (unchanged lines) that were already highlighted.

## Changes

- Removed the condition that restricted syntax highlighting to only context lines
- Updated the rendering logic to use syntax-highlighted content for all line types
- Simplified the conditional rendering by using the highlighted content consistently

## Before

Only context lines (unchanged) were syntax highlighted, while added and deleted lines showed plain text.

## After

All lines in the diff view (context, added, and deleted) now have syntax highlighting applied, improving code readability.

## Testing

- Built the project successfully with `go build`
- Verified the code changes maintain the existing highlight.js integration