### PR TITLE
feat: add automatic JSON export of comments and notes for agent access

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Git diff review tool with a web interface, inspired by GitHub's pull request U
 - ⚡ **Built with Go** - Fast, simple, and efficient
 - 🔌 **Automatic port allocation** - Each repository gets its own port
 - 🤖 **MCP Server Integration** - Allows LLMs like Claude to query and resolve review comments
+- 📄 **JSON Export** - Automatically exports comments/notes to a JSON file for easy agent access
 
 ## Quick Start
 
@@ -89,6 +90,7 @@ guck daemon stop-all   # Stop all daemons
 
 # Configuration
 guck config set base-branch develop
+guck config set export-path /custom/path/exports  # Custom JSON export folder
 guck config show
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,12 @@ guck config set base-branch develop
 # Get current base branch
 guck config get base-branch
 
+# Set custom export folder for JSON files (default: ~/.local/state/guck/exports/)
+guck config set export-path /custom/path/exports
+
+# Get current export path
+guck config get export-path
+
 # Show all configuration
 guck config show
 ```
@@ -114,7 +120,33 @@ guck config show
 Guck stores its data in XDG-compliant directories:
 
 - **State**: `~/.local/state/guck/` - Port mappings, daemon PIDs, viewed files, comments
-- **Config**: `~/.config/guck/` - User configuration (base branch, etc.)
+- **Config**: `~/.config/guck/` - User configuration (base branch, export path, etc.)
+
+### JSON Export for Agents
+
+Guck automatically exports comments and notes to JSON files whenever they change. Each repository gets its own export file, organized by a hash of the repo path.
+
+**Default Location**: `~/.local/state/guck/exports/<repo-hash>/comments_export.json`
+
+**Custom Location**: Configure with `guck config set export-path /your/path`, then files will be at `<export-path>/<repo-hash>/comments_export.json`
+
+The export file contains:
+```json
+{
+  "generated_at": "2025-12-11T13:00:00Z",
+  "repo_path": "/path/to/your/repo",
+  "comments": [...],
+  "notes": [...],
+  "summary": {
+    "total_comments": 5,
+    "unresolved_comments": 2,
+    "total_notes": 3,
+    "active_notes": 1
+  }
+}
+```
+
+This is useful for agents that prefer file-based access over MCP protocol, or for integrating with tools that can watch file changes. Each repo's comments are isolated in their own file to prevent unbounded growth.
 
 ## MCP Server Integration
 
@@ -461,6 +493,7 @@ go test ./...
 ├── internal/
 │   ├── config/          # Configuration management (XDG-compliant)
 │   ├── daemon/          # Daemon process management and port allocation
+│   ├── export/          # JSON export of comments/notes for agent access
 │   ├── git/             # Git operations and diff parsing (using go-git)
 │   ├── mcp/             # MCP server implementation
 │   │   ├── mcp.go      # Legacy tool functions (list_comments, resolve_comment)
@@ -468,7 +501,7 @@ go test ./...
 │   ├── server/          # HTTP server and REST API
 │   │   ├── server.go   # Server logic and handlers
 │   │   └── static/     # Web UI (HTML/CSS/React)
-│   └── state/           # State persistence (comments, viewed files)
+│   └── state/           # State persistence (comments, viewed files, auto-export)
 ├── docs/                # Documentation
 └── .github/workflows/   # CI/CD for releases
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 type Config struct {
 	BaseBranch string `toml:"base_branch"`
+	ExportPath string `toml:"export_path"`
 }
 
 func Load() (*Config, error) {

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -1,0 +1,156 @@
+// ABOUTME: Package export handles JSON export of comments and notes for agent consumption.
+// ABOUTME: Exports are organized per-repository in separate directories.
+
+package export
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type Comment struct {
+	ID         string `json:"id"`
+	FilePath   string `json:"file_path"`
+	LineNumber *int   `json:"line_number,omitempty"`
+	Text       string `json:"text"`
+	Timestamp  int64  `json:"timestamp"`
+	Branch     string `json:"branch"`
+	Commit     string `json:"commit"`
+	Resolved   bool   `json:"resolved"`
+	ResolvedBy string `json:"resolved_by,omitempty"`
+	ResolvedAt int64  `json:"resolved_at,omitempty"`
+}
+
+type Note struct {
+	ID          string            `json:"id"`
+	FilePath    string            `json:"file_path"`
+	LineNumber  *int              `json:"line_number,omitempty"`
+	Text        string            `json:"text"`
+	Timestamp   int64             `json:"timestamp"`
+	Branch      string            `json:"branch"`
+	Commit      string            `json:"commit"`
+	Author      string            `json:"author"`
+	Type        string            `json:"type"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	Dismissed   bool              `json:"dismissed"`
+	DismissedBy string            `json:"dismissed_by,omitempty"`
+	DismissedAt int64             `json:"dismissed_at,omitempty"`
+}
+
+type ExportData struct {
+	GeneratedAt string        `json:"generated_at"`
+	RepoPath    string        `json:"repo_path"`
+	Comments    []*Comment    `json:"comments"`
+	Notes       []*Note       `json:"notes"`
+	Summary     ExportSummary `json:"summary"`
+}
+
+type ExportSummary struct {
+	TotalComments      int `json:"total_comments"`
+	UnresolvedComments int `json:"unresolved_comments"`
+	TotalNotes         int `json:"total_notes"`
+	ActiveNotes        int `json:"active_notes"`
+}
+
+func Export(repoPath string, comments []*Comment, notes []*Note, outputPath string) error {
+	if comments == nil {
+		comments = []*Comment{}
+	}
+	if notes == nil {
+		notes = []*Note{}
+	}
+
+	exportData := &ExportData{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		RepoPath:    repoPath,
+		Comments:    comments,
+		Notes:       notes,
+		Summary:     calculateSummary(comments, notes),
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return fmt.Errorf("failed to create export directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(exportData, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize export data: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write export file: %w", err)
+	}
+
+	return nil
+}
+
+func GetExportPathForRepo(repoPath string) (string, error) {
+	return GetExportPathForRepoWithBase(repoPath, "")
+}
+
+func GetExportPathForRepoWithBase(repoPath, customBaseDir string) (string, error) {
+	var baseDir string
+	var err error
+
+	if customBaseDir != "" {
+		baseDir = customBaseDir
+	} else {
+		baseDir, err = getExportsDir()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	repoHash := hashRepoPath(repoPath)
+	return filepath.Join(baseDir, repoHash, "comments_export.json"), nil
+}
+
+func hashRepoPath(repoPath string) string {
+	hash := sha256.Sum256([]byte(repoPath))
+	return hex.EncodeToString(hash[:8])
+}
+
+func calculateSummary(comments []*Comment, notes []*Note) ExportSummary {
+	unresolvedComments := 0
+	for _, c := range comments {
+		if !c.Resolved {
+			unresolvedComments++
+		}
+	}
+
+	activeNotes := 0
+	for _, n := range notes {
+		if !n.Dismissed {
+			activeNotes++
+		}
+	}
+
+	return ExportSummary{
+		TotalComments:      len(comments),
+		UnresolvedComments: unresolvedComments,
+		TotalNotes:         len(notes),
+		ActiveNotes:        activeNotes,
+	}
+}
+
+func getExportsDir() (string, error) {
+	if stateHome := os.Getenv("XDG_STATE_HOME"); stateHome != "" {
+		return filepath.Join(stateHome, "guck", "exports"), nil
+	}
+
+	if dataHome := os.Getenv("XDG_DATA_HOME"); dataHome != "" {
+		return filepath.Join(dataHome, "guck", "exports"), nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine home directory: %w", err)
+	}
+
+	return filepath.Join(home, ".local", "state", "guck", "exports"), nil
+}

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -1,0 +1,468 @@
+// ABOUTME: Tests for the export package that handles JSON export of comments and notes.
+// ABOUTME: Tests cover empty state, comments, notes, summary counts, and file output.
+
+package export
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestExportEmptyState(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "comments_export.json")
+
+	err := Export("/test/repo", nil, nil, outputPath)
+	if err != nil {
+		t.Fatalf("Failed to export empty state: %v", err)
+	}
+
+	// Verify file was created
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		t.Fatal("Export file should exist")
+	}
+
+	// Read and parse the file
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read export file: %v", err)
+	}
+
+	var exportData ExportData
+	if err := json.Unmarshal(data, &exportData); err != nil {
+		t.Fatalf("Failed to parse export JSON: %v", err)
+	}
+
+	// Verify structure
+	if exportData.GeneratedAt == "" {
+		t.Error("GeneratedAt should be set")
+	}
+
+	if exportData.Comments == nil {
+		t.Error("Comments should be initialized (not nil)")
+	}
+
+	if len(exportData.Comments) != 0 {
+		t.Errorf("Expected 0 comments, got %d", len(exportData.Comments))
+	}
+
+	if exportData.Notes == nil {
+		t.Error("Notes should be initialized (not nil)")
+	}
+
+	if len(exportData.Notes) != 0 {
+		t.Errorf("Expected 0 notes, got %d", len(exportData.Notes))
+	}
+
+	if exportData.Summary.TotalComments != 0 {
+		t.Errorf("Expected 0 total comments, got %d", exportData.Summary.TotalComments)
+	}
+}
+
+func TestExportWithComments(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "comments_export.json")
+
+	lineNum := 42
+	comment := &Comment{
+		ID:         "123-0",
+		FilePath:   "internal/server/server.go",
+		LineNumber: &lineNum,
+		Text:       "This needs better error handling",
+		Timestamp:  time.Now().Unix(),
+		Branch:     "feat/test",
+		Commit:     "abc1234",
+		Resolved:   false,
+	}
+	comments := []*Comment{comment}
+
+	err := Export("/test/repo", comments, nil, outputPath)
+	if err != nil {
+		t.Fatalf("Failed to export: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read export file: %v", err)
+	}
+
+	var exportData ExportData
+	if err := json.Unmarshal(data, &exportData); err != nil {
+		t.Fatalf("Failed to parse export JSON: %v", err)
+	}
+
+	if exportData.RepoPath != "/test/repo" {
+		t.Errorf("Expected RepoPath /test/repo, got %s", exportData.RepoPath)
+	}
+
+	if len(exportData.Comments) != 1 {
+		t.Fatalf("Expected 1 comment, got %d", len(exportData.Comments))
+	}
+
+	exported := exportData.Comments[0]
+	if exported.ID != comment.ID {
+		t.Errorf("Expected ID %s, got %s", comment.ID, exported.ID)
+	}
+
+	if exported.FilePath != comment.FilePath {
+		t.Errorf("Expected FilePath %s, got %s", comment.FilePath, exported.FilePath)
+	}
+
+	if exported.Text != comment.Text {
+		t.Errorf("Expected Text %s, got %s", comment.Text, exported.Text)
+	}
+
+	if exported.Resolved != comment.Resolved {
+		t.Errorf("Expected Resolved %v, got %v", comment.Resolved, exported.Resolved)
+	}
+}
+
+func TestExportWithNotes(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "comments_export.json")
+
+	lineNum := 85
+	note := &Note{
+		ID:         "456-0",
+		FilePath:   "internal/state/state.go",
+		LineNumber: &lineNum,
+		Text:       "Consider adding indexing for larger datasets",
+		Timestamp:  time.Now().Unix(),
+		Branch:     "feat/test",
+		Commit:     "abc1234",
+		Author:     "claude",
+		Type:       "suggestion",
+		Dismissed:  false,
+	}
+	notes := []*Note{note}
+
+	err := Export("/test/repo", nil, notes, outputPath)
+	if err != nil {
+		t.Fatalf("Failed to export: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read export file: %v", err)
+	}
+
+	var exportData ExportData
+	if err := json.Unmarshal(data, &exportData); err != nil {
+		t.Fatalf("Failed to parse export JSON: %v", err)
+	}
+
+	if len(exportData.Notes) != 1 {
+		t.Fatalf("Expected 1 note, got %d", len(exportData.Notes))
+	}
+
+	exported := exportData.Notes[0]
+	if exported.ID != note.ID {
+		t.Errorf("Expected ID %s, got %s", note.ID, exported.ID)
+	}
+
+	if exported.Author != note.Author {
+		t.Errorf("Expected Author %s, got %s", note.Author, exported.Author)
+	}
+
+	if exported.Type != note.Type {
+		t.Errorf("Expected Type %s, got %s", note.Type, exported.Type)
+	}
+}
+
+func TestExportMixedContent(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "comments_export.json")
+
+	lineNum := 10
+	comment1 := &Comment{
+		ID:       "c1",
+		FilePath: "file1.go",
+		Text:     "Comment 1",
+		Branch:   "main",
+		Commit:   "commit1",
+		Resolved: false,
+	}
+	comment2 := &Comment{
+		ID:         "c2",
+		FilePath:   "file2.go",
+		LineNumber: &lineNum,
+		Text:       "Comment 2",
+		Branch:     "main",
+		Commit:     "commit1",
+		Resolved:   true,
+		ResolvedBy: "user",
+	}
+	note1 := &Note{
+		ID:        "n1",
+		FilePath:  "file1.go",
+		Text:      "Note 1",
+		Branch:    "main",
+		Commit:    "commit1",
+		Author:    "claude",
+		Type:      "explanation",
+		Dismissed: false,
+	}
+
+	comments := []*Comment{comment1, comment2}
+	notes := []*Note{note1}
+
+	err := Export("/test/repo", comments, notes, outputPath)
+	if err != nil {
+		t.Fatalf("Failed to export: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read export file: %v", err)
+	}
+
+	var exportData ExportData
+	if err := json.Unmarshal(data, &exportData); err != nil {
+		t.Fatalf("Failed to parse export JSON: %v", err)
+	}
+
+	if len(exportData.Comments) != 2 {
+		t.Errorf("Expected 2 comments, got %d", len(exportData.Comments))
+	}
+
+	if len(exportData.Notes) != 1 {
+		t.Errorf("Expected 1 note, got %d", len(exportData.Notes))
+	}
+}
+
+func TestExportSummary(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "comments_export.json")
+
+	// Add 3 comments: 2 unresolved, 1 resolved
+	comments := []*Comment{
+		{ID: "c1", Resolved: false},
+		{ID: "c2", Resolved: false},
+		{ID: "c3", Resolved: true},
+	}
+
+	// Add 2 notes: 1 active, 1 dismissed
+	notes := []*Note{
+		{ID: "n1", Dismissed: false},
+		{ID: "n2", Dismissed: true},
+	}
+
+	err := Export("/test/repo", comments, notes, outputPath)
+	if err != nil {
+		t.Fatalf("Failed to export: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read export file: %v", err)
+	}
+
+	var exportData ExportData
+	if err := json.Unmarshal(data, &exportData); err != nil {
+		t.Fatalf("Failed to parse export JSON: %v", err)
+	}
+
+	if exportData.Summary.TotalComments != 3 {
+		t.Errorf("Expected 3 total comments, got %d", exportData.Summary.TotalComments)
+	}
+
+	if exportData.Summary.UnresolvedComments != 2 {
+		t.Errorf("Expected 2 unresolved comments, got %d", exportData.Summary.UnresolvedComments)
+	}
+
+	if exportData.Summary.TotalNotes != 2 {
+		t.Errorf("Expected 2 total notes, got %d", exportData.Summary.TotalNotes)
+	}
+
+	if exportData.Summary.ActiveNotes != 1 {
+		t.Errorf("Expected 1 active note, got %d", exportData.Summary.ActiveNotes)
+	}
+}
+
+func TestExportCustomPath(t *testing.T) {
+	tempDir := t.TempDir()
+	customPath := filepath.Join(tempDir, "custom", "nested", "export.json")
+
+	comments := []*Comment{{ID: "c1", Text: "test"}}
+
+	err := Export("/test/repo", comments, nil, customPath)
+	if err != nil {
+		t.Fatalf("Failed to export to custom path: %v", err)
+	}
+
+	// Verify file was created at custom path
+	if _, err := os.Stat(customPath); os.IsNotExist(err) {
+		t.Fatal("Export file should exist at custom path")
+	}
+
+	// Verify content
+	data, err := os.ReadFile(customPath)
+	if err != nil {
+		t.Fatalf("Failed to read export file: %v", err)
+	}
+
+	var exportData ExportData
+	if err := json.Unmarshal(data, &exportData); err != nil {
+		t.Fatalf("Failed to parse export JSON: %v", err)
+	}
+
+	if len(exportData.Comments) != 1 {
+		t.Errorf("Expected 1 comment, got %d", len(exportData.Comments))
+	}
+}
+
+func TestExportIsValidJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "comments_export.json")
+
+	lineNum := 42
+	metadata := map[string]string{"model": "claude-sonnet-4", "context": "review"}
+	comments := []*Comment{{
+		ID:         "c1",
+		FilePath:   "file.go",
+		LineNumber: &lineNum,
+		Text:       "Comment with \"quotes\" and\nnewlines",
+		Branch:     "main",
+		Commit:     "c1",
+		Resolved:   true,
+		ResolvedBy: "user",
+		ResolvedAt: time.Now().Unix(),
+	}}
+	notes := []*Note{{
+		ID:          "n1",
+		FilePath:    "file.go",
+		LineNumber:  &lineNum,
+		Text:        "Note with special chars: <>&",
+		Branch:      "main",
+		Commit:      "c1",
+		Author:      "claude",
+		Type:        "suggestion",
+		Metadata:    metadata,
+		Dismissed:   true,
+		DismissedBy: "user",
+		DismissedAt: time.Now().Unix(),
+	}}
+
+	err := Export("/test/repo", comments, notes, outputPath)
+	if err != nil {
+		t.Fatalf("Failed to export: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read export file: %v", err)
+	}
+
+	// Should be valid JSON
+	var result interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Export is not valid JSON: %v", err)
+	}
+
+	// Should be able to round-trip back to ExportData
+	var exportData ExportData
+	if err := json.Unmarshal(data, &exportData); err != nil {
+		t.Fatalf("Failed to unmarshal to ExportData: %v", err)
+	}
+
+	if exportData.Comments[0].Text != "Comment with \"quotes\" and\nnewlines" {
+		t.Error("Comment text not preserved correctly")
+	}
+
+	if exportData.Notes[0].Metadata["model"] != "claude-sonnet-4" {
+		t.Error("Note metadata not preserved correctly")
+	}
+}
+
+func TestExportMultipleRepos(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "comments_export.json")
+
+	// Simulate comments/notes from multiple repos (already flattened by caller)
+	comments := []*Comment{
+		{ID: "c1", Text: "Repo 1 comment"},
+		{ID: "c2", Text: "Repo 2 comment"},
+	}
+	notes := []*Note{
+		{ID: "n1", Text: "Repo 1 note"},
+	}
+
+	err := Export("/test/repo", comments, notes, outputPath)
+	if err != nil {
+		t.Fatalf("Failed to export: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read export file: %v", err)
+	}
+
+	var exportData ExportData
+	if err := json.Unmarshal(data, &exportData); err != nil {
+		t.Fatalf("Failed to parse export JSON: %v", err)
+	}
+
+	// Should have all comments/notes
+	if len(exportData.Comments) != 2 {
+		t.Errorf("Expected 2 comments, got %d", len(exportData.Comments))
+	}
+
+	if len(exportData.Notes) != 1 {
+		t.Errorf("Expected 1 note, got %d", len(exportData.Notes))
+	}
+}
+
+func TestGetExportPathForRepo(t *testing.T) {
+	path1, err := GetExportPathForRepo("/test/repo1")
+	if err != nil {
+		t.Fatalf("Failed to get export path: %v", err)
+	}
+
+	path2, err := GetExportPathForRepo("/test/repo2")
+	if err != nil {
+		t.Fatalf("Failed to get export path: %v", err)
+	}
+
+	// Different repos should have different paths
+	if path1 == path2 {
+		t.Error("Different repos should have different export paths")
+	}
+
+	// Same repo should have same path
+	path1Again, err := GetExportPathForRepo("/test/repo1")
+	if err != nil {
+		t.Fatalf("Failed to get export path: %v", err)
+	}
+
+	if path1 != path1Again {
+		t.Error("Same repo should have same export path")
+	}
+
+	// Should end with comments_export.json
+	if filepath.Base(path1) != "comments_export.json" {
+		t.Errorf("Expected filename comments_export.json, got %s", filepath.Base(path1))
+	}
+}
+
+func TestHashRepoPath(t *testing.T) {
+	hash1 := hashRepoPath("/test/repo1")
+	hash2 := hashRepoPath("/test/repo2")
+
+	if hash1 == hash2 {
+		t.Error("Different paths should have different hashes")
+	}
+
+	// Should be consistent
+	hash1Again := hashRepoPath("/test/repo1")
+	if hash1 != hash1Again {
+		t.Error("Same path should have same hash")
+	}
+
+	// Should be 16 chars (8 bytes hex encoded)
+	if len(hash1) != 16 {
+		t.Errorf("Expected hash length 16, got %d", len(hash1))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -727,8 +727,16 @@ func setConfig(c *cli.Context) error {
 		successColor.Print("✓ Set ")
 		infoColor.Print("base-branch")
 		successColor.Printf(" to '%s'\n", value)
+	case "export-path":
+		cfg.ExportPath = value
+		if err := cfg.Save(); err != nil {
+			return err
+		}
+		successColor.Print("✓ Set ")
+		infoColor.Print("export-path")
+		successColor.Printf(" to '%s'\n", value)
 	default:
-		return fmt.Errorf("unknown configuration key: %s", key)
+		return fmt.Errorf("unknown configuration key: %s (valid keys: base-branch, export-path)", key)
 	}
 
 	return nil
@@ -749,8 +757,14 @@ func getConfig(c *cli.Context) error {
 	switch key {
 	case "base-branch":
 		fmt.Println(cfg.BaseBranch)
+	case "export-path":
+		if cfg.ExportPath == "" {
+			fmt.Println("(default: ~/.local/state/guck/exports/)")
+		} else {
+			fmt.Println(cfg.ExportPath)
+		}
 	default:
-		return fmt.Errorf("unknown configuration key: %s", key)
+		return fmt.Errorf("unknown configuration key: %s (valid keys: base-branch, export-path)", key)
 	}
 
 	return nil
@@ -764,6 +778,13 @@ func showConfig(c *cli.Context) error {
 
 	infoColor.Print("base-branch = ")
 	successColor.Println(cfg.BaseBranch)
+
+	infoColor.Print("export-path = ")
+	if cfg.ExportPath == "" {
+		successColor.Println("(default: ~/.local/state/guck/exports/)")
+	} else {
+		successColor.Println(cfg.ExportPath)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Automatically exports comments and notes to JSON files whenever state
changes, allowing AI agents to read review data directly from the file
system without using MCP commands.

Each repository gets its own export file organized by repo path hash:
~/.local/state/guck/exports/<repo-hash>/comments_export.json

The export path is configurable via 'guck config set export-path'.

- Add internal/export package with per-repo Export() function and tests
- Add ExportPath config option for custom export folder location
- Integrate export into state.Manager.save() method
- Add CLI commands for export-path configuration (get/set/show)
- Update documentation with new feature and configuration
