### PR TITLE
feat: Add visual image diff viewer with Git LFS support

### DIFF
--- a/internal/git/blob.go
+++ b/internal/git/blob.go
@@ -1,0 +1,180 @@
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// LFS pointer signature
+const lfsPointerSignature = "version https://git-lfs.github.com/spec/v1"
+
+// ReadBlobCommit reads blob content from a specific commit using git show
+func (r *Repo) ReadBlobCommit(ref, path string) ([]byte, error) {
+	repoPath, err := r.RepoPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repo path: %w", err)
+	}
+
+	// Use git show <ref>:<path> to get the blob content
+	cmd := exec.Command("git", "show", fmt.Sprintf("%s:%s", ref, path))
+	cmd.Dir = repoPath
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read blob at %s:%s: %w", ref, path, err)
+	}
+
+	// Check if this is an LFS pointer and smudge if needed
+	if IsLFSPointer(output) {
+		smudged, err := r.SmudgeLFS(output, path)
+		if err != nil {
+			// If smudge fails, return the original pointer content
+			// This allows the UI to show something rather than failing completely
+			return output, nil
+		}
+		return smudged, nil
+	}
+
+	return output, nil
+}
+
+// ReadBlobIndex reads blob content from the git index (staged version)
+func (r *Repo) ReadBlobIndex(path string) ([]byte, error) {
+	repoPath, err := r.RepoPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repo path: %w", err)
+	}
+
+	// Use git show :<path> to get the index version
+	cmd := exec.Command("git", "show", fmt.Sprintf(":%s", path))
+	cmd.Dir = repoPath
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read blob from index for %s: %w", path, err)
+	}
+
+	// Check if this is an LFS pointer and smudge if needed
+	if IsLFSPointer(output) {
+		smudged, err := r.SmudgeLFS(output, path)
+		if err != nil {
+			return output, nil
+		}
+		return smudged, nil
+	}
+
+	return output, nil
+}
+
+// ReadBlobWorktree reads file content directly from the working directory
+func (r *Repo) ReadBlobWorktree(path string) ([]byte, error) {
+	repoPath, err := r.RepoPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repo path: %w", err)
+	}
+
+	fullPath := filepath.Join(repoPath, path)
+
+	// Security check: ensure the path is within the repo
+	absPath, err := filepath.Abs(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path: %w", err)
+	}
+	if !strings.HasPrefix(absPath, repoPath) {
+		return nil, fmt.Errorf("path escapes repository: %s", path)
+	}
+
+	content, err := os.ReadFile(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read worktree file %s: %w", path, err)
+	}
+
+	// Worktree files should already be smudged by git, but check just in case
+	// (this can happen if someone manually created an LFS pointer file)
+	if IsLFSPointer(content) {
+		smudged, err := r.SmudgeLFS(content, path)
+		if err != nil {
+			return content, nil
+		}
+		return smudged, nil
+	}
+
+	return content, nil
+}
+
+// IsLFSPointer checks if the given content is a Git LFS pointer
+func IsLFSPointer(content []byte) bool {
+	// LFS pointers are small text files starting with the LFS signature
+	// They're typically under 200 bytes
+	if len(content) > 500 {
+		return false
+	}
+
+	return bytes.HasPrefix(content, []byte(lfsPointerSignature))
+}
+
+// SmudgeLFS converts an LFS pointer to its actual content by running git lfs smudge
+func (r *Repo) SmudgeLFS(pointer []byte, path string) ([]byte, error) {
+	repoPath, err := r.RepoPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repo path: %w", err)
+	}
+
+	// Check if git-lfs is available
+	if _, err := exec.LookPath("git-lfs"); err != nil {
+		return nil, fmt.Errorf("git-lfs is not installed: %w", err)
+	}
+
+	// Run git lfs smudge with the pointer content on stdin
+	cmd := exec.Command("git", "lfs", "smudge", path)
+	cmd.Dir = repoPath
+	cmd.Stdin = bytes.NewReader(pointer)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git lfs smudge failed: %s: %w", stderr.String(), err)
+	}
+
+	return stdout.Bytes(), nil
+}
+
+// GetMIMEType returns the MIME type for a file based on its extension
+func GetMIMEType(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".bmp":
+		return "image/bmp"
+	case ".svg":
+		return "image/svg+xml"
+	case ".ico":
+		return "image/x-icon"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// IsImagePath checks if the path points to an image file based on extension
+func IsImagePath(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg", ".ico":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/git/blob_test.go
+++ b/internal/git/blob_test.go
@@ -1,0 +1,355 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsLFSPointer(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		want    bool
+	}{
+		{
+			name: "valid LFS pointer",
+			content: []byte(`version https://git-lfs.github.com/spec/v1
+oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+size 12345
+`),
+			want: true,
+		},
+		{
+			name: "LFS pointer without trailing newline",
+			content: []byte(`version https://git-lfs.github.com/spec/v1
+oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393
+size 12345`),
+			want: true,
+		},
+		{
+			name:    "regular text file",
+			content: []byte("Hello, world!\n"),
+			want:    false,
+		},
+		{
+			name:    "binary content",
+			content: []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, // PNG header
+			want:    false,
+		},
+		{
+			name:    "empty content",
+			content: []byte{},
+			want:    false,
+		},
+		{
+			name:    "content starting with version but not LFS",
+			content: []byte("version 1.0.0\nsome other content"),
+			want:    false,
+		},
+		{
+			name:    "large file should not be LFS pointer",
+			content: make([]byte, 600), // LFS pointers are < 500 bytes
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsLFSPointer(tt.content)
+			if got != tt.want {
+				t.Errorf("IsLFSPointer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetMIMEType(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"image.png", "image/png"},
+		{"photo.jpg", "image/jpeg"},
+		{"photo.jpeg", "image/jpeg"},
+		{"animation.gif", "image/gif"},
+		{"modern.webp", "image/webp"},
+		{"legacy.bmp", "image/bmp"},
+		{"vector.svg", "image/svg+xml"},
+		{"favicon.ico", "image/x-icon"},
+		{"document.pdf", "application/octet-stream"},
+		{"script.js", "application/octet-stream"},
+		{"noextension", "application/octet-stream"},
+		// Case insensitivity
+		{"IMAGE.PNG", "image/png"},
+		{"Photo.JPG", "image/jpeg"},
+		{"path/to/nested/image.png", "image/png"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := GetMIMEType(tt.path)
+			if got != tt.want {
+				t.Errorf("GetMIMEType(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsImagePath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"image.png", true},
+		{"photo.jpg", true},
+		{"photo.jpeg", true},
+		{"animation.gif", true},
+		{"modern.webp", true},
+		{"legacy.bmp", true},
+		{"vector.svg", true},
+		{"favicon.ico", true},
+		{"document.pdf", false},
+		{"script.js", false},
+		{"style.css", false},
+		{"noextension", false},
+		{"", false},
+		// Case insensitivity
+		{"IMAGE.PNG", true},
+		{"Photo.JPG", true},
+		// Nested paths
+		{"path/to/nested/image.png", true},
+		{"assets/icons/logo.svg", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := IsImagePath(tt.path)
+			if got != tt.want {
+				t.Errorf("IsImagePath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadBlobWorktree(t *testing.T) {
+	tempDir := setupTestRepo(t)
+
+	repo, err := Open(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to open repo: %v", err)
+	}
+
+	// Create a test file
+	testContent := []byte("test file content\n")
+	testPath := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(testPath, testContent, 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	// Read the file through ReadBlobWorktree
+	content, err := repo.ReadBlobWorktree("test.txt")
+	if err != nil {
+		t.Fatalf("ReadBlobWorktree failed: %v", err)
+	}
+
+	if string(content) != string(testContent) {
+		t.Errorf("ReadBlobWorktree returned %q, want %q", string(content), string(testContent))
+	}
+}
+
+func TestReadBlobWorktreeNonExistent(t *testing.T) {
+	tempDir := setupTestRepo(t)
+
+	repo, err := Open(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to open repo: %v", err)
+	}
+
+	// Try to read a non-existent file
+	_, err = repo.ReadBlobWorktree("nonexistent.txt")
+	if err == nil {
+		t.Error("Expected error for non-existent file, got nil")
+	}
+}
+
+func TestReadBlobWorktreePathTraversal(t *testing.T) {
+	tempDir := setupTestRepo(t)
+
+	repo, err := Open(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to open repo: %v", err)
+	}
+
+	// Try to escape the repository
+	_, err = repo.ReadBlobWorktree("../../../etc/passwd")
+	if err == nil {
+		t.Error("Expected error for path traversal, got nil")
+	}
+}
+
+func TestReadBlobWorktreeNestedPath(t *testing.T) {
+	tempDir := setupTestRepo(t)
+
+	repo, err := Open(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to open repo: %v", err)
+	}
+
+	// Create a nested directory and file
+	nestedDir := filepath.Join(tempDir, "subdir", "nested")
+	if err := os.MkdirAll(nestedDir, 0755); err != nil {
+		t.Fatalf("Failed to create nested directory: %v", err)
+	}
+
+	testContent := []byte("nested content\n")
+	testPath := filepath.Join(nestedDir, "file.txt")
+	if err := os.WriteFile(testPath, testContent, 0644); err != nil {
+		t.Fatalf("Failed to write nested file: %v", err)
+	}
+
+	// Read the nested file
+	content, err := repo.ReadBlobWorktree("subdir/nested/file.txt")
+	if err != nil {
+		t.Fatalf("ReadBlobWorktree failed for nested file: %v", err)
+	}
+
+	if string(content) != string(testContent) {
+		t.Errorf("ReadBlobWorktree returned %q, want %q", string(content), string(testContent))
+	}
+}
+
+func TestReadBlobCommit(t *testing.T) {
+	tempDir := setupTestRepo(t)
+
+	repo, err := Open(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to open repo: %v", err)
+	}
+
+	// The initial commit created README.md with "# Test Repo\n"
+	content, err := repo.ReadBlobCommit("HEAD", "README.md")
+	if err != nil {
+		t.Fatalf("ReadBlobCommit failed: %v", err)
+	}
+
+	expected := "# Test Repo\n"
+	if string(content) != expected {
+		t.Errorf("ReadBlobCommit returned %q, want %q", string(content), expected)
+	}
+}
+
+func TestReadBlobCommitNonExistent(t *testing.T) {
+	tempDir := setupTestRepo(t)
+
+	repo, err := Open(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to open repo: %v", err)
+	}
+
+	// Try to read a non-existent file
+	_, err = repo.ReadBlobCommit("HEAD", "nonexistent.txt")
+	if err == nil {
+		t.Error("Expected error for non-existent file, got nil")
+	}
+}
+
+func TestReadBlobCommitInvalidRef(t *testing.T) {
+	tempDir := setupTestRepo(t)
+
+	repo, err := Open(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to open repo: %v", err)
+	}
+
+	// Try to read from an invalid ref
+	_, err = repo.ReadBlobCommit("invalid-ref-12345", "README.md")
+	if err == nil {
+		t.Error("Expected error for invalid ref, got nil")
+	}
+}
+
+func TestReadBlobIndex(t *testing.T) {
+	tempDir := setupTestRepo(t)
+
+	repo, err := Open(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to open repo: %v", err)
+	}
+
+	// Create and stage a new file
+	testContent := []byte("staged content\n")
+	testPath := filepath.Join(tempDir, "staged.txt")
+	if err := os.WriteFile(testPath, testContent, 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+	runGit(t, tempDir, "add", "staged.txt")
+
+	// Read from index
+	content, err := repo.ReadBlobIndex("staged.txt")
+	if err != nil {
+		t.Fatalf("ReadBlobIndex failed: %v", err)
+	}
+
+	if string(content) != string(testContent) {
+		t.Errorf("ReadBlobIndex returned %q, want %q", string(content), string(testContent))
+	}
+}
+
+func TestReadBlobIndexModifiedStaged(t *testing.T) {
+	tempDir := setupTestRepo(t)
+
+	repo, err := Open(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to open repo: %v", err)
+	}
+
+	// Modify and stage README.md
+	stagedContent := []byte("# Modified and Staged\n")
+	readmePath := filepath.Join(tempDir, "README.md")
+	if err := os.WriteFile(readmePath, stagedContent, 0644); err != nil {
+		t.Fatalf("Failed to modify file: %v", err)
+	}
+	runGit(t, tempDir, "add", "README.md")
+
+	// Now modify it again in worktree (but don't stage)
+	worktreeContent := []byte("# Modified in Worktree\n")
+	if err := os.WriteFile(readmePath, worktreeContent, 0644); err != nil {
+		t.Fatalf("Failed to modify file again: %v", err)
+	}
+
+	// ReadBlobIndex should return the staged version
+	content, err := repo.ReadBlobIndex("README.md")
+	if err != nil {
+		t.Fatalf("ReadBlobIndex failed: %v", err)
+	}
+
+	if string(content) != string(stagedContent) {
+		t.Errorf("ReadBlobIndex returned %q, want staged content %q", string(content), string(stagedContent))
+	}
+
+	// ReadBlobWorktree should return the worktree version
+	worktreeRead, err := repo.ReadBlobWorktree("README.md")
+	if err != nil {
+		t.Fatalf("ReadBlobWorktree failed: %v", err)
+	}
+
+	if string(worktreeRead) != string(worktreeContent) {
+		t.Errorf("ReadBlobWorktree returned %q, want worktree content %q", string(worktreeRead), string(worktreeContent))
+	}
+}
+
+func TestReadBlobIndexNonExistent(t *testing.T) {
+	tempDir := setupTestRepo(t)
+
+	repo, err := Open(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to open repo: %v", err)
+	}
+
+	// Try to read a file that's not in the index
+	_, err = repo.ReadBlobIndex("nonexistent.txt")
+	if err == nil {
+		t.Error("Expected error for non-existent file in index, got nil")
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -27,11 +27,20 @@ const (
 
 type FileInfo struct {
 	Path          string        `json:"path"`
+	FromPath      string        `json:"from_path,omitempty"` // Original path for renames/deletes
+	ToPath        string        `json:"to_path,omitempty"`   // New path for renames/adds
 	Status        string        `json:"status"`
 	Additions     int           `json:"additions"`
 	Deletions     int           `json:"deletions"`
 	Patch         string        `json:"patch"`
 	StagingStatus StagingStatus `json:"staging_status,omitempty"`
+}
+
+// DiffResult contains the result of a diff operation including commit references
+type DiffResult struct {
+	BaseCommit string     // The merge-base commit hash used for comparison
+	HeadCommit string     // The HEAD commit hash
+	Files      []FileInfo // Changed files
 }
 
 func Open(path string) (*Repo, error) {
@@ -96,7 +105,7 @@ func (r *Repo) GetRemoteURL() (string, error) {
 	return remote.Config().URLs[0], nil
 }
 
-func (r *Repo) GetDiffFiles(baseBranch string) ([]FileInfo, error) {
+func (r *Repo) GetDiffFiles(baseBranch string) (DiffResult, error) {
 	// Try to get the remote tracking branch first (origin/baseBranch)
 	// This ensures we compare against the remote version even if local is outdated
 	remoteBranchRef, err := r.repo.Reference(plumbing.NewRemoteReferenceName("origin", baseBranch), true)
@@ -106,62 +115,65 @@ func (r *Repo) GetDiffFiles(baseBranch string) ([]FileInfo, error) {
 		// Remote tracking branch exists, use it
 		baseCommit, err = r.repo.CommitObject(remoteBranchRef.Hash())
 		if err != nil {
-			return nil, fmt.Errorf("failed to get remote base commit: %w", err)
+			return DiffResult{}, fmt.Errorf("failed to get remote base commit: %w", err)
 		}
 	} else {
 		// Fall back to local branch if remote tracking branch doesn't exist
 		baseBranchRef, err := r.repo.Reference(plumbing.NewBranchReferenceName(baseBranch), true)
 		if err != nil {
-			return nil, fmt.Errorf("failed to find branch %s: %w", baseBranch, err)
+			return DiffResult{}, fmt.Errorf("failed to find branch %s: %w", baseBranch, err)
 		}
 
 		baseCommit, err = r.repo.CommitObject(baseBranchRef.Hash())
 		if err != nil {
-			return nil, fmt.Errorf("failed to get base commit: %w", err)
+			return DiffResult{}, fmt.Errorf("failed to get base commit: %w", err)
 		}
 	}
 
 	// Get the current HEAD commit
 	head, err := r.repo.Head()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get HEAD: %w", err)
+		return DiffResult{}, fmt.Errorf("failed to get HEAD: %w", err)
 	}
 
 	headCommit, err := r.repo.CommitObject(head.Hash())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get HEAD commit: %w", err)
+		return DiffResult{}, fmt.Errorf("failed to get HEAD commit: %w", err)
 	}
 
 	// Find the merge base between base branch and HEAD
 	mergeBase, err := headCommit.MergeBase(baseCommit)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find merge base: %w", err)
+		return DiffResult{}, fmt.Errorf("failed to find merge base: %w", err)
 	}
 
 	// Use the merge base as the comparison point
 	var baseTree *object.Tree
+	var baseCommitHash string
 	if len(mergeBase) > 0 {
 		baseTree, err = mergeBase[0].Tree()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get merge base tree: %w", err)
+			return DiffResult{}, fmt.Errorf("failed to get merge base tree: %w", err)
 		}
+		baseCommitHash = mergeBase[0].Hash.String()
 	} else {
 		// Fallback to base branch if no merge base found
 		baseTree, err = baseCommit.Tree()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get base tree: %w", err)
+			return DiffResult{}, fmt.Errorf("failed to get base tree: %w", err)
 		}
+		baseCommitHash = baseCommit.Hash.String()
 	}
 
 	headTree, err := headCommit.Tree()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get HEAD tree: %w", err)
+		return DiffResult{}, fmt.Errorf("failed to get HEAD tree: %w", err)
 	}
 
 	// Get the diff
 	changes, err := baseTree.Diff(headTree)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create diff: %w", err)
+		return DiffResult{}, fmt.Errorf("failed to create diff: %w", err)
 	}
 
 	files := []FileInfo{}
@@ -172,18 +184,23 @@ func (r *Repo) GetDiffFiles(baseBranch string) ([]FileInfo, error) {
 			continue
 		}
 
-		filePath := change.To.Name
+		// Set FromPath and ToPath for proper rename/add/delete tracking
+		fromPath := change.From.Name
+		toPath := change.To.Name
+
+		// Path is the "canonical" path for display (prefer ToPath, fallback to FromPath)
+		filePath := toPath
 		if filePath == "" {
-			filePath = change.From.Name
+			filePath = fromPath
 		}
 
 		status := "modified"
 		switch {
-		case change.From.Name == "":
+		case fromPath == "":
 			status = "added"
-		case change.To.Name == "":
+		case toPath == "":
 			status = "deleted"
-		case change.From.Name != change.To.Name:
+		case fromPath != toPath:
 			status = "renamed"
 		}
 
@@ -206,6 +223,8 @@ func (r *Repo) GetDiffFiles(baseBranch string) ([]FileInfo, error) {
 
 		files = append(files, FileInfo{
 			Path:      filePath,
+			FromPath:  fromPath,
+			ToPath:    toPath,
 			Status:    status,
 			Additions: additions,
 			Deletions: deletions,
@@ -213,47 +232,74 @@ func (r *Repo) GetDiffFiles(baseBranch string) ([]FileInfo, error) {
 		})
 	}
 
-	return files, nil
+	return DiffResult{
+		BaseCommit: baseCommitHash,
+		HeadCommit: headCommit.Hash.String(),
+		Files:      files,
+	}, nil
 }
 
 // GetUncommittedChanges returns all uncommitted changes (both staged and unstaged)
+// Uses native git status to properly handle LFS-tracked files
 func (r *Repo) GetUncommittedChanges() ([]FileInfo, error) {
 	repoPath, err := r.RepoPath()
 	if err != nil {
 		return nil, err
 	}
 
-	wt, err := r.repo.Worktree()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get worktree: %w", err)
-	}
+	// Use native git status --porcelain to properly handle LFS files
+	// go-git's Status() compares raw content (LFS pointer vs smudged content)
+	// which incorrectly reports LFS files as having changes
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = repoPath
 
-	status, err := wt.Status()
+	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get worktree status: %w", err)
+		return nil, fmt.Errorf("failed to get git status: %w", err)
 	}
 
 	files := []FileInfo{}
 
-	for filePath, fileStatus := range status {
-		// Check if file has staged changes (index vs HEAD)
-		if fileStatus.Staging != git.Unmodified && fileStatus.Staging != git.Untracked {
-			fileInfo, err := r.getFileInfoWithGitDiff(repoPath, filePath, fileStatus.Staging, StagingStatusStaged)
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if len(line) < 3 {
+			continue
+		}
+
+		// Porcelain format: XY filename
+		// X = index status, Y = worktree status
+		indexStatus := line[0]
+		worktreeStatus := line[1]
+		filePath := strings.TrimSpace(line[3:])
+
+		// Handle renamed files (format: "R  old -> new")
+		if strings.Contains(filePath, " -> ") {
+			parts := strings.Split(filePath, " -> ")
+			if len(parts) == 2 {
+				filePath = parts[1] // Use the new path
+			}
+		}
+
+		// Check for staged changes (index vs HEAD)
+		if indexStatus != ' ' && indexStatus != '?' {
+			statusCode := porcelainToStatusCode(indexStatus)
+			fileInfo, err := r.getFileInfoWithGitDiff(repoPath, filePath, statusCode, StagingStatusStaged)
 			if err == nil {
 				files = append(files, fileInfo)
 			}
 		}
 
-		// Check if file has unstaged changes (worktree vs index)
-		if fileStatus.Worktree != git.Unmodified && fileStatus.Worktree != git.Untracked {
-			fileInfo, err := r.getFileInfoWithGitDiff(repoPath, filePath, fileStatus.Worktree, StagingStatusUnstaged)
+		// Check for unstaged changes (worktree vs index)
+		if worktreeStatus != ' ' && worktreeStatus != '?' {
+			statusCode := porcelainToStatusCode(worktreeStatus)
+			fileInfo, err := r.getFileInfoWithGitDiff(repoPath, filePath, statusCode, StagingStatusUnstaged)
 			if err == nil {
 				files = append(files, fileInfo)
 			}
 		}
 
-		// Handle untracked files as unstaged additions
-		if fileStatus.Worktree == git.Untracked {
+		// Handle untracked files
+		if indexStatus == '?' && worktreeStatus == '?' {
 			content, err := r.readWorktreeFile(filePath)
 			if err != nil {
 				continue
@@ -280,6 +326,24 @@ func (r *Repo) GetUncommittedChanges() ([]FileInfo, error) {
 	}
 
 	return files, nil
+}
+
+// porcelainToStatusCode converts git status porcelain format to go-git StatusCode
+func porcelainToStatusCode(c byte) git.StatusCode {
+	switch c {
+	case 'M':
+		return git.Modified
+	case 'A':
+		return git.Added
+	case 'D':
+		return git.Deleted
+	case 'R':
+		return git.Renamed
+	case 'C':
+		return git.Copied
+	default:
+		return git.Modified
+	}
 }
 
 // getFileInfoWithGitDiff uses git diff command for proper unified diff output

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sync"
 
 	"github.com/gorilla/mux"
@@ -27,18 +28,24 @@ type DiffResponse struct {
 	UncommittedFiles []FileDiff `json:"uncommitted_files,omitempty"`
 	Branch           string     `json:"branch"`
 	Commit           string     `json:"commit"`
+	BaseCommit       string     `json:"base_commit,omitempty"`
 	RepoPath         string     `json:"repo_path"`
 	RemoteURL        string     `json:"remote_url,omitempty"`
 }
 
 type FileDiff struct {
 	Path          string `json:"path"`
+	FromPath      string `json:"from_path,omitempty"`
+	ToPath        string `json:"to_path,omitempty"`
 	Status        string `json:"status"`
 	Additions     int    `json:"additions"`
 	Deletions     int    `json:"deletions"`
 	Patch         string `json:"patch"`
 	Viewed        bool   `json:"viewed"`
 	StagingStatus string `json:"staging_status,omitempty"`
+	IsImage       bool   `json:"is_image,omitempty"`
+	ImageBaseURL  string `json:"image_base_url,omitempty"`
+	ImageHeadURL  string `json:"image_head_url,omitempty"`
 }
 
 type MarkViewedRequest struct {
@@ -103,6 +110,7 @@ func Start(port int, baseBranch string) error {
 	r := mux.NewRouter()
 	r.HandleFunc("/", appState.indexHandler).Methods("GET")
 	r.HandleFunc("/api/diff", appState.diffHandler).Methods("GET")
+	r.HandleFunc("/api/blob", appState.blobHandler).Methods("GET")
 	r.HandleFunc("/api/mark-viewed", appState.markViewedHandler).Methods("POST")
 	r.HandleFunc("/api/unmark-viewed", appState.unmarkViewedHandler).Methods("POST")
 	r.HandleFunc("/api/status", appState.statusHandler).Methods("GET")
@@ -149,25 +157,56 @@ func (s *AppState) diffHandler(w http.ResponseWriter, r *http.Request) {
 
 	remoteURL, _ := gitRepo.GetRemoteURL() // Ignore error, remote is optional
 
-	files, err := gitRepo.GetDiffFiles(s.BaseBranch)
+	diffResult, err := gitRepo.GetDiffFiles(s.BaseBranch)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	fileDiffs := []FileDiff{}
-	for _, file := range files {
+	for _, file := range diffResult.Files {
 		viewed := s.StateManager.IsFileViewed(s.RepoPath, currentBranch, currentCommit, file.Path)
 
-		fileDiffs = append(fileDiffs, FileDiff{
+		fileDiff := FileDiff{
 			Path:          file.Path,
+			FromPath:      file.FromPath,
+			ToPath:        file.ToPath,
 			Status:        file.Status,
 			Additions:     file.Additions,
 			Deletions:     file.Deletions,
 			Patch:         file.Patch,
 			Viewed:        viewed,
 			StagingStatus: string(git.StagingStatusCommitted),
-		})
+		}
+
+		// Populate image URLs for image files
+		if git.IsImagePath(file.Path) {
+			fileDiff.IsImage = true
+
+			// Determine base path (for renames, use FromPath; otherwise use Path)
+			basePath := file.Path
+			if file.FromPath != "" {
+				basePath = file.FromPath
+			}
+
+			// Determine head path (for renames, use ToPath; otherwise use Path)
+			headPath := file.Path
+			if file.ToPath != "" {
+				headPath = file.ToPath
+			}
+
+			// Base URL (not for added files)
+			if file.Status != "added" {
+				fileDiff.ImageBaseURL = buildBlobURL("commit", diffResult.BaseCommit, basePath)
+			}
+
+			// Head URL (not for deleted files)
+			if file.Status != "deleted" {
+				fileDiff.ImageHeadURL = buildBlobURL("commit", diffResult.HeadCommit, headPath)
+			}
+		}
+
+		fileDiffs = append(fileDiffs, fileDiff)
 	}
 
 	// Get uncommitted changes
@@ -179,15 +218,42 @@ func (s *AppState) diffHandler(w http.ResponseWriter, r *http.Request) {
 			uncommittedCommit := "__uncommitted__"
 			viewed := s.StateManager.IsFileViewed(s.RepoPath, currentBranch, uncommittedCommit, file.Path+":"+string(file.StagingStatus))
 
-			uncommittedFileDiffs = append(uncommittedFileDiffs, FileDiff{
+			fileDiff := FileDiff{
 				Path:          file.Path,
+				FromPath:      file.FromPath,
+				ToPath:        file.ToPath,
 				Status:        file.Status,
 				Additions:     file.Additions,
 				Deletions:     file.Deletions,
 				Patch:         file.Patch,
 				Viewed:        viewed,
 				StagingStatus: string(file.StagingStatus),
-			})
+			}
+
+			// Populate image URLs for uncommitted image files
+			if git.IsImagePath(file.Path) {
+				fileDiff.IsImage = true
+
+				if file.StagingStatus == git.StagingStatusStaged {
+					// Staged: base is HEAD, head is index
+					if file.Status != "added" {
+						fileDiff.ImageBaseURL = buildBlobURL("commit", "HEAD", file.Path)
+					}
+					if file.Status != "deleted" {
+						fileDiff.ImageHeadURL = buildBlobURL("index", "", file.Path)
+					}
+				} else {
+					// Unstaged: base is index (or HEAD), head is worktree
+					if file.Status != "added" {
+						fileDiff.ImageBaseURL = buildBlobURL("index", "", file.Path)
+					}
+					if file.Status != "deleted" {
+						fileDiff.ImageHeadURL = buildBlobURL("worktree", "", file.Path)
+					}
+				}
+			}
+
+			uncommittedFileDiffs = append(uncommittedFileDiffs, fileDiff)
 		}
 	}
 
@@ -196,12 +262,82 @@ func (s *AppState) diffHandler(w http.ResponseWriter, r *http.Request) {
 		UncommittedFiles: uncommittedFileDiffs,
 		Branch:           currentBranch,
 		Commit:           currentCommit,
+		BaseCommit:       diffResult.BaseCommit,
 		RepoPath:         s.RepoPath,
 		RemoteURL:        remoteURL,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(response) // Ignore encode error for HTTP response
+}
+
+// buildBlobURL constructs a URL for the /api/blob endpoint
+func buildBlobURL(source, ref, path string) string {
+	params := url.Values{}
+	params.Set("source", source)
+	if ref != "" {
+		params.Set("ref", ref)
+	}
+	params.Set("path", path)
+	return "/api/blob?" + params.Encode()
+}
+
+// blobHandler serves blob content for images with LFS support
+func (s *AppState) blobHandler(w http.ResponseWriter, r *http.Request) {
+	source := r.URL.Query().Get("source")
+	ref := r.URL.Query().Get("ref")
+	path := r.URL.Query().Get("path")
+
+	if path == "" {
+		http.Error(w, "path parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	if source != "commit" && source != "index" && source != "worktree" {
+		http.Error(w, "source must be 'commit', 'index', or 'worktree'", http.StatusBadRequest)
+		return
+	}
+
+	if source == "commit" && ref == "" {
+		http.Error(w, "ref parameter is required when source is 'commit'", http.StatusBadRequest)
+		return
+	}
+
+	gitRepo, err := git.Open(".")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var content []byte
+	switch source {
+	case "commit":
+		content, err = gitRepo.ReadBlobCommit(ref, path)
+	case "index":
+		content, err = gitRepo.ReadBlobIndex(path)
+	case "worktree":
+		content, err = gitRepo.ReadBlobWorktree(path)
+	}
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	// Set appropriate headers
+	contentType := git.GetMIMEType(path)
+	w.Header().Set("Content-Type", contentType)
+
+	// Set caching headers
+	if source == "commit" {
+		// Committed content is immutable, cache aggressively
+		w.Header().Set("Cache-Control", "private, max-age=31536000, immutable")
+	} else {
+		// Index and worktree content can change, don't cache
+		w.Header().Set("Cache-Control", "no-store")
+	}
+
+	_, _ = w.Write(content)
 }
 
 func (s *AppState) markViewedHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -466,9 +466,9 @@
             }
 
             .image-diff-mode-toggle button.active {
-                background-color: #0969da;
-                color: white;
-                border-color: #0969da;
+                background-color: var(--bgColor-accent-emphasis, #0969da);
+                color: var(--fgColor-onEmphasis, white);
+                border-color: var(--bgColor-accent-emphasis, #0969da);
             }
 
             .image-diff-2up {
@@ -634,7 +634,7 @@
                 top: 0;
                 bottom: 0;
                 width: 3px;
-                background-color: #fff;
+                background-color: var(--bgColor-default, #fff);
                 box-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
                 transform: translateX(-50%);
                 z-index: 10;
@@ -647,8 +647,8 @@
                 top: 50%;
                 left: 50%;
                 transform: translate(-50%, -50%);
-                background-color: #fff;
-                color: #666;
+                background-color: var(--bgColor-default, #fff);
+                color: var(--fgColor-muted, #666);
                 font-size: 10px;
                 padding: 8px 6px;
                 border-radius: 4px;
@@ -660,9 +660,26 @@
             }
 
             .swipe-divider:hover::before,
-            .swipe-divider.dragging::before {
-                background-color: #0969da;
-                color: #fff;
+            .swipe-divider.dragging::before,
+            .swipe-divider:focus::before {
+                background-color: var(--bgColor-accent-emphasis, #0969da);
+                color: var(--fgColor-onEmphasis, #fff);
+            }
+
+            .swipe-divider:focus {
+                outline: none;
+            }
+
+            .swipe-divider:focus::after {
+                content: '';
+                position: absolute;
+                top: -2px;
+                bottom: -2px;
+                left: -4px;
+                right: -4px;
+                border: 2px solid var(--bgColor-accent-emphasis, #0969da);
+                border-radius: 4px;
+                pointer-events: none;
             }
 
             .swipe-dimensions {
@@ -1599,17 +1616,22 @@
 
                     // Render Swipe mode - custom implementation with both images clipped
                     const swipeContainerRef = React.useRef(null);
+                    const cachedRectRef = React.useRef(null);
                     const [isDragging, setIsDragging] = React.useState(false);
 
                     const handleDragStart = (e) => {
                         e.preventDefault();
+                        // Cache bounding rect on drag start for performance
+                        if (swipeContainerRef.current) {
+                            cachedRectRef.current = swipeContainerRef.current.getBoundingClientRect();
+                        }
                         setIsDragging(true);
                     };
 
                     const handleDragMove = React.useCallback((e) => {
-                        if (!isDragging || !swipeContainerRef.current) return;
+                        if (!isDragging || !cachedRectRef.current) return;
 
-                        const rect = swipeContainerRef.current.getBoundingClientRect();
+                        const rect = cachedRectRef.current;
                         const clientX = e.touches ? e.touches[0].clientX : e.clientX;
                         const x = clientX - rect.left;
                         const percentage = Math.max(0, Math.min(100, (x / rect.width) * 100));
@@ -1618,6 +1640,25 @@
 
                     const handleDragEnd = React.useCallback(() => {
                         setIsDragging(false);
+                        cachedRectRef.current = null;
+                    }, []);
+
+                    // Keyboard handler for accessibility
+                    const handleKeyDown = React.useCallback((e) => {
+                        const step = e.shiftKey ? 10 : 1; // Larger steps with shift
+                        if (e.key === 'ArrowLeft') {
+                            e.preventDefault();
+                            setSliderValue(v => Math.max(0, v - step));
+                        } else if (e.key === 'ArrowRight') {
+                            e.preventDefault();
+                            setSliderValue(v => Math.min(100, v + step));
+                        } else if (e.key === 'Home') {
+                            e.preventDefault();
+                            setSliderValue(0);
+                        } else if (e.key === 'End') {
+                            e.preventDefault();
+                            setSliderValue(100);
+                        }
                     }, []);
 
                     // Add/remove global event listeners for drag
@@ -1674,6 +1715,13 @@
                                     <div
                                         className={`swipe-divider ${isDragging ? 'dragging' : ''}`}
                                         style={{ left: `${sliderValue}%` }}
+                                        tabIndex={0}
+                                        role="slider"
+                                        aria-label="Image comparison slider"
+                                        aria-valuemin={0}
+                                        aria-valuemax={100}
+                                        aria-valuenow={Math.round(sliderValue)}
+                                        onKeyDown={handleKeyDown}
                                     />
                                 </div>
                                 {(baseDims || headDims) && (
@@ -1879,6 +1927,7 @@
                                                 );
                                             })
                                             .map((line, index) => {
+                                                if (line.length === 0) return null;
                                                 const prefix = line[0];
                                                 let lineClass = "context";
                                                 if (prefix === "+") lineClass = "addition";

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -443,6 +443,460 @@
                 border-bottom-left-radius: 12px;
                 border-bottom-right-radius: 12px;
             }
+
+            /* Image Diff Styles */
+            .image-diff-container {
+                padding: 24px;
+                background-color: var(--bgColor-muted);
+            }
+
+            .image-diff-mode-toggle {
+                display: flex;
+                gap: 8px;
+                margin-bottom: 16px;
+            }
+
+            .image-diff-mode-toggle button {
+                padding: 4px 12px;
+                border: 1px solid var(--borderColor-default);
+                border-radius: 6px;
+                background-color: var(--bgColor-default);
+                cursor: pointer;
+                font-size: 12px;
+            }
+
+            .image-diff-mode-toggle button.active {
+                background-color: #0969da;
+                color: white;
+                border-color: #0969da;
+            }
+
+            .image-diff-2up {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: 24px;
+            }
+
+            .image-diff-single {
+                display: flex;
+                justify-content: center;
+            }
+
+            .image-frame {
+                text-align: center;
+            }
+
+            .image-frame-inner {
+                display: inline-block;
+                background-color: var(--bgColor-default);
+                border: 2px solid var(--borderColor-default);
+                border-radius: 6px;
+                padding: 16px;
+                /* Checkerboard pattern for transparency */
+                background-image:
+                    linear-gradient(45deg, #f0f0f0 25%, transparent 25%),
+                    linear-gradient(-45deg, #f0f0f0 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #f0f0f0 75%),
+                    linear-gradient(-45deg, transparent 75%, #f0f0f0 75%);
+                background-size: 16px 16px;
+                background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
+                background-color: #fff;
+            }
+
+            [data-color-mode="dark"] .image-frame-inner {
+                background-image:
+                    linear-gradient(45deg, #2d2d2d 25%, transparent 25%),
+                    linear-gradient(-45deg, #2d2d2d 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #2d2d2d 75%),
+                    linear-gradient(-45deg, transparent 75%, #2d2d2d 75%);
+                background-color: #1c1c1c;
+            }
+
+            .image-frame.deletion .image-frame-inner {
+                border-color: var(--borderColor-danger-emphasis, #cf222e);
+            }
+
+            .image-frame.addition .image-frame-inner {
+                border-color: var(--borderColor-success-emphasis, #1a7f37);
+            }
+
+            .image-frame img {
+                max-width: 100%;
+                max-height: 500px;
+                object-fit: contain;
+                display: block;
+            }
+
+            .image-label {
+                font-size: 12px;
+                font-weight: 600;
+                color: var(--fgColor-muted);
+                margin-bottom: 8px;
+                text-transform: uppercase;
+            }
+
+            .image-meta {
+                font-size: 13px;
+                color: var(--fgColor-muted);
+                margin-top: 12px;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+            }
+
+            .image-meta-deletion {
+                color: var(--fgColor-danger, #cf222e);
+            }
+
+            .image-meta-addition {
+                color: var(--fgColor-success, #1a7f37);
+            }
+
+            .image-error {
+                padding: 24px;
+                text-align: center;
+                color: var(--fgColor-danger);
+                background-color: var(--bgColor-danger-muted);
+                border-radius: 6px;
+            }
+
+            .image-open-link {
+                font-size: 11px;
+                margin-top: 8px;
+            }
+
+            .dimension-change {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 8px;
+                padding: 8px 12px;
+                margin-bottom: 16px;
+                background-color: var(--bgColor-attention-muted);
+                border: 1px solid var(--borderColor-attention-muted);
+                border-radius: 6px;
+                font-size: 12px;
+            }
+
+            /* Swipe Mode Styles - custom implementation */
+            .swipe-container {
+                border: 1px solid var(--borderColor-default);
+                border-radius: 8px;
+                overflow: hidden;
+                background-color: var(--bgColor-default);
+            }
+
+            .swipe-images {
+                position: relative;
+                width: 100%;
+                min-height: 200px;
+                /* Checkerboard background for transparency */
+                background-image:
+                    linear-gradient(45deg, #e0e0e0 25%, transparent 25%),
+                    linear-gradient(-45deg, #e0e0e0 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #e0e0e0 75%),
+                    linear-gradient(-45deg, transparent 75%, #e0e0e0 75%);
+                background-size: 16px 16px;
+                background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
+                background-color: #f5f5f5;
+                user-select: none;
+            }
+
+            [data-color-mode="dark"] .swipe-images {
+                background-image:
+                    linear-gradient(45deg, #2d2d2d 25%, transparent 25%),
+                    linear-gradient(-45deg, #2d2d2d 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #2d2d2d 75%),
+                    linear-gradient(-45deg, transparent 75%, #2d2d2d 75%);
+                background-color: #1c1c1c;
+            }
+
+            .swipe-img {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                object-fit: contain;
+                object-position: center;
+            }
+
+            /* Make the first image (before) set the container height */
+            .swipe-before {
+                position: relative;
+                max-height: 500px;
+            }
+
+            .swipe-after {
+                max-height: 500px;
+            }
+
+            .swipe-divider {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                width: 3px;
+                background-color: #fff;
+                box-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
+                transform: translateX(-50%);
+                z-index: 10;
+                cursor: ew-resize;
+            }
+
+            .swipe-divider::before {
+                content: '◀ ▶';
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%);
+                background-color: #fff;
+                color: #666;
+                font-size: 10px;
+                padding: 8px 6px;
+                border-radius: 4px;
+                box-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
+                white-space: nowrap;
+                letter-spacing: 2px;
+                cursor: ew-resize;
+                user-select: none;
+            }
+
+            .swipe-divider:hover::before,
+            .swipe-divider.dragging::before {
+                background-color: #0969da;
+                color: #fff;
+            }
+
+            .swipe-dimensions {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                padding: 12px 16px;
+                font-size: 13px;
+                background-color: var(--bgColor-muted);
+                border-top: 1px solid var(--borderColor-default);
+            }
+
+            /* Pointer diff toggle for LFS images */
+            .pointer-diff-toggle {
+                margin-top: 16px;
+                font-size: 12px;
+            }
+
+            .pointer-diff-toggle summary {
+                cursor: pointer;
+                color: var(--fgColor-muted);
+            }
+
+            .pointer-diff-toggle summary:hover {
+                color: var(--fgColor-default);
+            }
+
+            /* Onion Skin Mode Styles */
+            .onion-container {
+                border: 1px solid var(--borderColor-default);
+                border-radius: 8px;
+                overflow: hidden;
+                background-color: var(--bgColor-default);
+            }
+
+            .onion-images {
+                position: relative;
+                width: 100%;
+                min-height: 200px;
+                /* Checkerboard background for transparency */
+                background-image:
+                    linear-gradient(45deg, #e0e0e0 25%, transparent 25%),
+                    linear-gradient(-45deg, #e0e0e0 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #e0e0e0 75%),
+                    linear-gradient(-45deg, transparent 75%, #e0e0e0 75%);
+                background-size: 16px 16px;
+                background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
+                background-color: #f5f5f5;
+            }
+
+            [data-color-mode="dark"] .onion-images {
+                background-image:
+                    linear-gradient(45deg, #2d2d2d 25%, transparent 25%),
+                    linear-gradient(-45deg, #2d2d2d 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #2d2d2d 75%),
+                    linear-gradient(-45deg, transparent 75%, #2d2d2d 75%);
+                background-color: #1c1c1c;
+            }
+
+            .onion-img {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                object-fit: contain;
+                object-position: center;
+            }
+
+            .onion-bottom {
+                position: relative;
+                max-height: 500px;
+            }
+
+            .onion-top {
+                max-height: 500px;
+                pointer-events: none;
+            }
+
+            .onion-controls {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 16px;
+                padding: 12px 16px;
+                background-color: var(--bgColor-muted);
+                border-top: 1px solid var(--borderColor-default);
+            }
+
+            .onion-slider-group {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+            }
+
+            .onion-slider-group input[type="range"] {
+                width: 150px;
+                cursor: pointer;
+            }
+
+            .onion-slider-label {
+                font-size: 12px;
+                color: var(--fgColor-muted);
+                min-width: 45px;
+            }
+
+            .onion-swap-btn {
+                font-size: 12px;
+                padding: 4px 12px;
+                border-radius: 4px;
+                border: 1px solid var(--borderColor-default);
+                background-color: var(--bgColor-default);
+                color: var(--fgColor-default);
+                cursor: pointer;
+            }
+
+            .onion-swap-btn:hover {
+                background-color: var(--bgColor-muted);
+            }
+
+            /* Blink/Flicker Mode Styles */
+            .blink-container {
+                border: 1px solid var(--borderColor-default);
+                border-radius: 8px;
+                overflow: hidden;
+                background-color: var(--bgColor-default);
+            }
+
+            .blink-images {
+                position: relative;
+                width: 100%;
+                min-height: 200px;
+                /* Checkerboard background for transparency */
+                background-image:
+                    linear-gradient(45deg, #e0e0e0 25%, transparent 25%),
+                    linear-gradient(-45deg, #e0e0e0 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #e0e0e0 75%),
+                    linear-gradient(-45deg, transparent 75%, #e0e0e0 75%);
+                background-size: 16px 16px;
+                background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
+                background-color: #f5f5f5;
+            }
+
+            [data-color-mode="dark"] .blink-images {
+                background-image:
+                    linear-gradient(45deg, #2d2d2d 25%, transparent 25%),
+                    linear-gradient(-45deg, #2d2d2d 25%, transparent 25%),
+                    linear-gradient(45deg, transparent 75%, #2d2d2d 75%),
+                    linear-gradient(-45deg, transparent 75%, #2d2d2d 75%);
+                background-color: #1c1c1c;
+            }
+
+            .blink-img {
+                max-width: 100%;
+                max-height: 500px;
+                object-fit: contain;
+                display: block;
+                margin: 0 auto;
+            }
+
+            .blink-controls {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 16px;
+                padding: 12px 16px;
+                background-color: var(--bgColor-muted);
+                border-top: 1px solid var(--borderColor-default);
+            }
+
+            .blink-play-btn {
+                font-size: 14px;
+                padding: 4px 16px;
+                border-radius: 4px;
+                border: 1px solid var(--borderColor-default);
+                background-color: var(--bgColor-default);
+                color: var(--fgColor-default);
+                cursor: pointer;
+                min-width: 70px;
+            }
+
+            .blink-play-btn:hover {
+                background-color: var(--bgColor-muted);
+            }
+
+            .blink-play-btn.playing {
+                background-color: var(--bgColor-attention-muted);
+                border-color: var(--borderColor-attention-muted);
+            }
+
+            .blink-speed-group {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+            }
+
+            .blink-speed-group select {
+                font-size: 12px;
+                padding: 4px 8px;
+                border-radius: 4px;
+                border: 1px solid var(--borderColor-default);
+                background-color: var(--bgColor-default);
+                color: var(--fgColor-default);
+                cursor: pointer;
+            }
+
+            .blink-indicator {
+                font-size: 12px;
+                color: var(--fgColor-muted);
+                min-width: 50px;
+                text-align: center;
+            }
+
+            .blink-indicator.before {
+                color: var(--fgColor-danger, #cf222e);
+            }
+
+            .blink-indicator.after {
+                color: var(--fgColor-success, #1a7f37);
+            }
+
+            /* Mode-specific controls row */
+            .image-diff-controls {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 16px;
+                padding: 8px 12px;
+                margin-bottom: 12px;
+                background-color: var(--bgColor-muted);
+                border: 1px solid var(--borderColor-default);
+                border-radius: 6px;
+                font-size: 12px;
+            }
         </style>
     </head>
     <body>
@@ -981,6 +1435,469 @@
                     );
                 }
 
+                // ImageDiff component for 2-Up, Swipe, Onion, and Blink modes
+                function ImageDiff({ baseUrl, headUrl, status, patch }) {
+                    const [mode, setMode] = useState(() => {
+                        const stored = localStorage.getItem("guck-image-diff-mode");
+                        return stored || "2up";
+                    });
+                    const [baseDims, setBaseDims] = useState(null);
+                    const [headDims, setHeadDims] = useState(null);
+                    const [baseError, setBaseError] = useState(false);
+                    const [headError, setHeadError] = useState(false);
+                    const [sliderValue, setSliderValue] = useState(50);
+
+                    // Onion skin state
+                    const [onionOpacity, setOnionOpacity] = useState(() => {
+                        const stored = localStorage.getItem("guck-image-onion-opacity");
+                        return stored ? parseInt(stored, 10) : 50;
+                    });
+                    const [onionSwapped, setOnionSwapped] = useState(() => {
+                        const stored = localStorage.getItem("guck-image-onion-swapped");
+                        return stored === "true";
+                    });
+
+                    // Blink mode state
+                    const [blinkHz, setBlinkHz] = useState(() => {
+                        const stored = localStorage.getItem("guck-image-blink-hz");
+                        return stored ? parseInt(stored, 10) : 4;
+                    });
+                    const [blinkPlaying, setBlinkPlaying] = useState(true);
+                    const [showBefore, setShowBefore] = useState(true);
+
+                    const handleModeChange = (newMode) => {
+                        setMode(newMode);
+                        localStorage.setItem("guck-image-diff-mode", newMode);
+                    };
+
+                    const handleOnionOpacityChange = (value) => {
+                        setOnionOpacity(value);
+                        localStorage.setItem("guck-image-onion-opacity", value.toString());
+                    };
+
+                    const handleOnionSwap = () => {
+                        const newValue = !onionSwapped;
+                        setOnionSwapped(newValue);
+                        localStorage.setItem("guck-image-onion-swapped", newValue.toString());
+                    };
+
+                    const handleBlinkHzChange = (value) => {
+                        setBlinkHz(value);
+                        localStorage.setItem("guck-image-blink-hz", value.toString());
+                    };
+
+                    // Blink effect
+                    React.useEffect(() => {
+                        if (mode !== "blink" || !blinkPlaying) return;
+                        const interval = setInterval(() => {
+                            setShowBefore(v => !v);
+                        }, 1000 / blinkHz);
+                        return () => clearInterval(interval);
+                    }, [mode, blinkHz, blinkPlaying]);
+
+                    const handleBaseLoad = (e) => {
+                        setBaseDims({
+                            width: e.target.naturalWidth,
+                            height: e.target.naturalHeight,
+                        });
+                    };
+
+                    const handleHeadLoad = (e) => {
+                        setHeadDims({
+                            width: e.target.naturalWidth,
+                            height: e.target.naturalHeight,
+                        });
+                    };
+
+                    const hasBothImages = baseUrl && headUrl;
+                    const showDimensionChange = baseDims && headDims &&
+                        (baseDims.width !== headDims.width || baseDims.height !== headDims.height);
+
+                    // Format dimensions like GitHub: "W: 533px | H: 533px"
+                    const formatDims = (dims, colorClass) => {
+                        if (!dims) return null;
+                        return (
+                            <div className={`image-meta ${colorClass || ''}`}>
+                                W: <span style={{ fontWeight: 500 }}>{dims.width}px</span> | H: <span style={{ fontWeight: 500 }}>{dims.height}px</span>
+                            </div>
+                        );
+                    };
+
+                    // Render 2-Up mode
+                    const render2Up = () => {
+                        if (!hasBothImages) {
+                            // Single image (added or deleted)
+                            const isAdded = status === "added";
+                            const dims = isAdded ? headDims : baseDims;
+                            const error = isAdded ? headError : baseError;
+                            const url = isAdded ? headUrl : baseUrl;
+                            const colorClass = isAdded ? "image-meta-addition" : "image-meta-deletion";
+                            const frameClass = isAdded ? "addition" : "deletion";
+
+                            return (
+                                <div className="image-diff-single">
+                                    <div className={`image-frame ${frameClass}`} style={{ maxWidth: "600px" }}>
+                                        {error ? (
+                                            <div className="image-error">Failed to load image</div>
+                                        ) : (
+                                            <>
+                                                <div className="image-frame-inner">
+                                                    <img
+                                                        src={url}
+                                                        alt={isAdded ? "Added" : "Deleted"}
+                                                        onLoad={isAdded ? handleHeadLoad : handleBaseLoad}
+                                                        onError={() => isAdded ? setHeadError(true) : setBaseError(true)}
+                                                    />
+                                                </div>
+                                                {formatDims(dims, colorClass)}
+                                            </>
+                                        )}
+                                    </div>
+                                </div>
+                            );
+                        }
+
+                        return (
+                            <div className="image-diff-2up">
+                                <div className="image-frame deletion">
+                                    {baseError ? (
+                                        <div className="image-error">Failed to load image</div>
+                                    ) : (
+                                        <>
+                                            <div className="image-frame-inner">
+                                                <img
+                                                    src={baseUrl}
+                                                    alt="Before"
+                                                    onLoad={handleBaseLoad}
+                                                    onError={() => setBaseError(true)}
+                                                />
+                                            </div>
+                                            {formatDims(baseDims, "image-meta-deletion")}
+                                        </>
+                                    )}
+                                </div>
+                                <div className="image-frame addition">
+                                    {headError ? (
+                                        <div className="image-error">Failed to load image</div>
+                                    ) : (
+                                        <>
+                                            <div className="image-frame-inner">
+                                                <img
+                                                    src={headUrl}
+                                                    alt="After"
+                                                    onLoad={handleHeadLoad}
+                                                    onError={() => setHeadError(true)}
+                                                />
+                                            </div>
+                                            {formatDims(headDims, "image-meta-addition")}
+                                        </>
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    };
+
+                    // Render Swipe mode - custom implementation with both images clipped
+                    const swipeContainerRef = React.useRef(null);
+                    const [isDragging, setIsDragging] = React.useState(false);
+
+                    const handleDragStart = (e) => {
+                        e.preventDefault();
+                        setIsDragging(true);
+                    };
+
+                    const handleDragMove = React.useCallback((e) => {
+                        if (!isDragging || !swipeContainerRef.current) return;
+
+                        const rect = swipeContainerRef.current.getBoundingClientRect();
+                        const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+                        const x = clientX - rect.left;
+                        const percentage = Math.max(0, Math.min(100, (x / rect.width) * 100));
+                        setSliderValue(percentage);
+                    }, [isDragging]);
+
+                    const handleDragEnd = React.useCallback(() => {
+                        setIsDragging(false);
+                    }, []);
+
+                    // Add/remove global event listeners for drag
+                    React.useEffect(() => {
+                        if (isDragging) {
+                            document.addEventListener('mousemove', handleDragMove);
+                            document.addEventListener('mouseup', handleDragEnd);
+                            document.addEventListener('touchmove', handleDragMove);
+                            document.addEventListener('touchend', handleDragEnd);
+                        }
+                        return () => {
+                            document.removeEventListener('mousemove', handleDragMove);
+                            document.removeEventListener('mouseup', handleDragEnd);
+                            document.removeEventListener('touchmove', handleDragMove);
+                            document.removeEventListener('touchend', handleDragEnd);
+                        };
+                    }, [isDragging, handleDragMove, handleDragEnd]);
+
+                    const renderSwipe = () => {
+                        if (!hasBothImages) {
+                            return render2Up(); // Fallback to 2-up for single images
+                        }
+
+                        return (
+                            <div className="swipe-container">
+                                <div
+                                    className="swipe-images"
+                                    ref={swipeContainerRef}
+                                    onMouseDown={handleDragStart}
+                                    onTouchStart={handleDragStart}
+                                    style={{ cursor: isDragging ? 'ew-resize' : 'default' }}
+                                >
+                                    {/* Before image: show from left edge to slider */}
+                                    <img
+                                        src={baseUrl}
+                                        alt="Before"
+                                        className="swipe-img swipe-before"
+                                        style={{ clipPath: `inset(0 ${100 - sliderValue}% 0 0)` }}
+                                        onLoad={handleBaseLoad}
+                                        onError={() => setBaseError(true)}
+                                        draggable={false}
+                                    />
+                                    {/* After image: show from slider to right edge */}
+                                    <img
+                                        src={headUrl}
+                                        alt="After"
+                                        className="swipe-img swipe-after"
+                                        style={{ clipPath: `inset(0 0 0 ${sliderValue}%)` }}
+                                        onLoad={handleHeadLoad}
+                                        onError={() => setHeadError(true)}
+                                        draggable={false}
+                                    />
+                                    {/* Divider line with draggable handle */}
+                                    <div
+                                        className={`swipe-divider ${isDragging ? 'dragging' : ''}`}
+                                        style={{ left: `${sliderValue}%` }}
+                                    />
+                                </div>
+                                {(baseDims || headDims) && (
+                                    <div className="swipe-dimensions">
+                                        {baseDims && (
+                                            <span className="image-meta-deletion">
+                                                W: {baseDims.width}px | H: {baseDims.height}px
+                                            </span>
+                                        )}
+                                        <span style={{ margin: "0 16px" }}>→</span>
+                                        {headDims && (
+                                            <span className="image-meta-addition">
+                                                W: {headDims.width}px | H: {headDims.height}px
+                                            </span>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    };
+
+                    // Render Onion Skin mode
+                    const renderOnion = () => {
+                        if (!hasBothImages) {
+                            return render2Up(); // Fallback to 2-up for single images
+                        }
+
+                        // Determine which image is on top based on swap state
+                        const bottomUrl = onionSwapped ? headUrl : baseUrl;
+                        const topUrl = onionSwapped ? baseUrl : headUrl;
+                        const bottomAlt = onionSwapped ? "After" : "Before";
+                        const topAlt = onionSwapped ? "Before" : "After";
+
+                        return (
+                            <div className="onion-container">
+                                <div className="onion-images">
+                                    {/* Bottom image (fully visible) */}
+                                    <img
+                                        src={bottomUrl}
+                                        alt={bottomAlt}
+                                        className="onion-img onion-bottom"
+                                        onLoad={onionSwapped ? handleHeadLoad : handleBaseLoad}
+                                        onError={() => onionSwapped ? setHeadError(true) : setBaseError(true)}
+                                    />
+                                    {/* Top image (with opacity) */}
+                                    <img
+                                        src={topUrl}
+                                        alt={topAlt}
+                                        className="onion-img onion-top"
+                                        style={{ opacity: onionOpacity / 100 }}
+                                        onLoad={onionSwapped ? handleBaseLoad : handleHeadLoad}
+                                        onError={() => onionSwapped ? setBaseError(true) : setHeadError(true)}
+                                    />
+                                </div>
+                                <div className="onion-controls">
+                                    <div className="onion-slider-group">
+                                        <span className="onion-slider-label">Opacity:</span>
+                                        <input
+                                            type="range"
+                                            min="0"
+                                            max="100"
+                                            value={onionOpacity}
+                                            onChange={(e) => handleOnionOpacityChange(parseInt(e.target.value, 10))}
+                                        />
+                                        <span className="onion-slider-label">{onionOpacity}%</span>
+                                    </div>
+                                    <button className="onion-swap-btn" onClick={handleOnionSwap}>
+                                        {onionSwapped ? "Before on top" : "After on top"}
+                                    </button>
+                                    <span style={{ fontSize: "11px", color: "var(--fgColor-muted)" }}>
+                                        (Currently: {onionSwapped ? "Before" : "After"} over {onionSwapped ? "After" : "Before"})
+                                    </span>
+                                </div>
+                            </div>
+                        );
+                    };
+
+                    // Render Blink/Flicker mode
+                    const renderBlink = () => {
+                        if (!hasBothImages) {
+                            return render2Up(); // Fallback to 2-up for single images
+                        }
+
+                        const currentUrl = showBefore ? baseUrl : headUrl;
+                        const currentAlt = showBefore ? "Before" : "After";
+
+                        return (
+                            <div className="blink-container">
+                                <div className="blink-images">
+                                    <img
+                                        src={currentUrl}
+                                        alt={currentAlt}
+                                        className="blink-img"
+                                        onLoad={showBefore ? handleBaseLoad : handleHeadLoad}
+                                        onError={() => showBefore ? setBaseError(true) : setHeadError(true)}
+                                    />
+                                </div>
+                                <div className="blink-controls">
+                                    <button
+                                        className={`blink-play-btn ${blinkPlaying ? "playing" : ""}`}
+                                        onClick={() => setBlinkPlaying(!blinkPlaying)}
+                                    >
+                                        {blinkPlaying ? "Pause" : "Play"}
+                                    </button>
+                                    <div className="blink-speed-group">
+                                        <span style={{ fontSize: "12px", color: "var(--fgColor-muted)" }}>Speed:</span>
+                                        <select
+                                            value={blinkHz}
+                                            onChange={(e) => handleBlinkHzChange(parseInt(e.target.value, 10))}
+                                        >
+                                            <option value="2">2 Hz</option>
+                                            <option value="3">3 Hz</option>
+                                            <option value="4">4 Hz</option>
+                                            <option value="5">5 Hz</option>
+                                            <option value="6">6 Hz</option>
+                                        </select>
+                                    </div>
+                                    <span className={`blink-indicator ${showBefore ? "before" : "after"}`}>
+                                        {showBefore ? "Before" : "After"}
+                                    </span>
+                                </div>
+                            </div>
+                        );
+                    };
+
+                    // Get current render function based on mode
+                    const renderContent = () => {
+                        switch (mode) {
+                            case "swipe":
+                                return renderSwipe();
+                            case "onion":
+                                return renderOnion();
+                            case "blink":
+                                return renderBlink();
+                            case "2up":
+                            default:
+                                return render2Up();
+                        }
+                    };
+
+                    return (
+                        <div className="image-diff-container">
+                            {/* Mode toggle - only show if we have both images */}
+                            {hasBothImages && (
+                                <div className="image-diff-mode-toggle">
+                                    <button
+                                        className={mode === "2up" ? "active" : ""}
+                                        onClick={() => handleModeChange("2up")}
+                                    >
+                                        2-Up
+                                    </button>
+                                    <button
+                                        className={mode === "swipe" ? "active" : ""}
+                                        onClick={() => handleModeChange("swipe")}
+                                    >
+                                        Swipe
+                                    </button>
+                                    <button
+                                        className={mode === "onion" ? "active" : ""}
+                                        onClick={() => handleModeChange("onion")}
+                                    >
+                                        Onion
+                                    </button>
+                                    <button
+                                        className={mode === "blink" ? "active" : ""}
+                                        onClick={() => handleModeChange("blink")}
+                                    >
+                                        Blink
+                                    </button>
+                                </div>
+                            )}
+
+                            {/* Dimension change indicator */}
+                            {showDimensionChange && (
+                                <div className="dimension-change">
+                                    <span>Size changed:</span>
+                                    <span>{baseDims.width} × {baseDims.height}</span>
+                                    <span>→</span>
+                                    <span>{headDims.width} × {headDims.height}</span>
+                                </div>
+                            )}
+
+                            {/* Render based on mode */}
+                            {renderContent()}
+
+                            {/* Optional: Show pointer diff for LFS files */}
+                            {patch && patch.includes("git-lfs.github.com") && (
+                                <details className="pointer-diff-toggle">
+                                    <summary>Show LFS pointer diff</summary>
+                                    <div className="file-diff-content mt-2">
+                                        {patch
+                                            .split("\n")
+                                            .filter((line) => {
+                                                return !(
+                                                    line.startsWith("diff --git") ||
+                                                    line.startsWith("index ") ||
+                                                    line.startsWith("--- ") ||
+                                                    line.startsWith("+++ ") ||
+                                                    line.startsWith("new file mode") ||
+                                                    line.startsWith("old file mode") ||
+                                                    line.startsWith("deleted file mode") ||
+                                                    line.startsWith("@@")
+                                                );
+                                            })
+                                            .map((line, index) => {
+                                                const prefix = line[0];
+                                                let lineClass = "context";
+                                                if (prefix === "+") lineClass = "addition";
+                                                else if (prefix === "-") lineClass = "deletion";
+
+                                                return (
+                                                    <div key={index} className={`diff-line ${lineClass}`}>
+                                                        <span className="diff-line-number">{index + 1}</span>
+                                                        <span className="diff-line-content">{line.slice(1)}</span>
+                                                    </div>
+                                                );
+                                            })}
+                                    </div>
+                                </details>
+                            )}
+                        </div>
+                    );
+                }
+
                 if (loading) {
                     return (
                         <div className="container-lg p-4">
@@ -1154,25 +2071,34 @@
                                                 </div>
                                                 {isExpanded && (
                                                     <div className="Box-body p-0">
-                                                        <div className="file-diff-content">
-                                                            {file.patch
-                                                                .split("\n")
-                                                                .filter((line) => {
-                                                                    return !(
-                                                                        line.startsWith("diff --git") ||
-                                                                        line.startsWith("index ") ||
-                                                                        line.startsWith("--- ") ||
-                                                                        line.startsWith("+++ ") ||
-                                                                        line.startsWith("new file mode") ||
-                                                                        line.startsWith("old file mode") ||
-                                                                        line.startsWith("deleted file mode") ||
-                                                                        line.startsWith("@@")
-                                                                    );
-                                                                })
-                                                                .map((line, index) =>
-                                                                    renderDiffLine(line, index, file.path, comments[file.path] || [])
-                                                                )}
-                                                        </div>
+                                                        {file.is_image ? (
+                                                            <ImageDiff
+                                                                baseUrl={file.image_base_url}
+                                                                headUrl={file.image_head_url}
+                                                                status={file.status}
+                                                                patch={file.patch}
+                                                            />
+                                                        ) : (
+                                                            <div className="file-diff-content">
+                                                                {file.patch
+                                                                    .split("\n")
+                                                                    .filter((line) => {
+                                                                        return !(
+                                                                            line.startsWith("diff --git") ||
+                                                                            line.startsWith("index ") ||
+                                                                            line.startsWith("--- ") ||
+                                                                            line.startsWith("+++ ") ||
+                                                                            line.startsWith("new file mode") ||
+                                                                            line.startsWith("old file mode") ||
+                                                                            line.startsWith("deleted file mode") ||
+                                                                            line.startsWith("@@")
+                                                                        );
+                                                                    })
+                                                                    .map((line, index) =>
+                                                                        renderDiffLine(line, index, file.path, comments[file.path] || [])
+                                                                    )}
+                                                            </div>
+                                                        )}
                                                     </div>
                                                 )}
                                             </div>
@@ -1294,8 +2220,15 @@
                                                     </div>
                                                 </div>
                                                 {isExpanded && (
-                                                    <>
-                                                        <div className="Box-body p-0">
+                                                    <div className="Box-body p-0">
+                                                        {file.is_image ? (
+                                                            <ImageDiff
+                                                                baseUrl={file.image_base_url}
+                                                                headUrl={file.image_head_url}
+                                                                status={file.status}
+                                                                patch={file.patch}
+                                                            />
+                                                        ) : (
                                                             <div className="file-diff-content">
                                                                 {file.patch
                                                                     .split("\n")
@@ -1348,8 +2281,8 @@
                                                                             ),
                                                                     )}
                                                             </div>
-                                                        </div>
-                                                    </>
+                                                        )}
+                                                    </div>
                                                 )}
                                             </div>
                                         );


### PR DESCRIPTION
## Summary

Adds a GitHub-style image diff viewer to Guck with full Git LFS support. When reviewing PRs that include image changes, users can now visually compare before/after versions using four different viewing modes.

## Features

### Image Diff Viewer
- **2-Up Mode**: Side-by-side comparison with colored borders (red for before, green for after)
- **Swipe Mode**: Drag a slider to reveal before/after with clip-path masking
- **Onion Skin Mode**: Overlay images with adjustable opacity slider and swap toggle
- **Blink Mode**: Rapid alternation between images at configurable speed (2-6 Hz)

### Git LFS Support
- Automatic detection of LFS pointers via signature checking
- Transparent smudging of LFS files to display actual image content
- Works with committed files, staged files, and working directory changes

### UI Polish
- Checkerboard background for transparency visualization
- Dimension display with size change indicators
- Dark mode support
- User preferences persisted to localStorage
- Graceful fallback for single images (added/deleted files)

## Technical Changes

### New Files
- `internal/git/blob.go` - Blob reading with LFS support
- `internal/git/blob_test.go` - Comprehensive test coverage

### Modified Files
- `internal/git/git.go` - Added `DiffResult` struct with commit hashes, fixed LFS handling in uncommitted changes by switching from go-git's `wt.Status()` to native `git status --porcelain`
- `internal/server/server.go` - New `/api/blob` endpoint with proper caching headers
- `internal/server/static/index.html` - `ImageDiff` React component with 4 viewing modes

## API

New endpoint: `GET /api/blob?source={commit|index|worktree}&ref={commit-hash}&path={file-path}`

- `source=commit` + `ref=<hash>` - Read from specific commit (cached immutably)
- `source=index` - Read from git staging area (no cache)
- `source=worktree` - Read from working directory (no cache)

## Testing

**Unit Tests Added:**
- `TestIsLFSPointer` - 7 test cases
- `TestGetMIMEType` - 14 test cases
- `TestIsImagePath` - 17 test cases
- `TestReadBlobWorktree` - Including path traversal security test
- `TestReadBlobCommit` - Including invalid ref handling
- `TestReadBlobIndex` - Including staged vs worktree distinction
- `TestPorcelainToStatusCode` - 7 test cases
- `TestDiffResultContainsCommitHashes`

**Manual Testing:**
1. Clone https://github.com/ajkolean/git-lfs-image-diff-test
2. Checkout branch `feature/image-change`
3. Run: `guck start --base main`
4. Open http://localhost:6969 and expand any image file to test the viewer

## Screenshots

The image diff viewer provides four modes for comparing images:

| Mode | Description |
|------|-------------|
| 2-Up | Side-by-side comparison |
| Swipe | Drag slider to reveal |
| Onion | Opacity overlay |
| Blink | Rapid alternation |

<img width="1388" height="1442" alt="guck-lfs-example" src="https://github.com/user-attachments/assets/5ae75f1b-6a86-44fe-80ba-e1c7b52a5a2b" />
